### PR TITLE
Fixed $setmoney showing wrong information

### DIFF
--- a/python/bot/cogs/misc/admin.py
+++ b/python/bot/cogs/misc/admin.py
@@ -65,7 +65,7 @@ class Admin(commands.Cog):
         embed: Embed = Embed(
             title="🏦",
             color=Color.green(),
-            description=f"Set {user}'s balance to ${amount_float}.",
+            description=f"Set **{member.display_name}**'s balance to **${amount_float:.2f}**.",
         )
 
         await ctx.send(embed=embed)


### PR DESCRIPTION
## Describe changes

Fixed $setmoney bug and formatted it a little better

## Issue number

Fixes #69

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [x] `.env.example` updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [x] Tested in Discord manually
- [x] `pytest` passes with no errors