### PR TITLE
AI Bug Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Dizznem Bot Changelog
 
+## [2.1.1] - 2026-5-12
+### Changed
+- Added per-user cooldown on AI chat to prevent spam.
+- Added global semaphore limiting concurrent AI API calls to 3.
+    - In other words only 3 AI calls can be made at once, the rest waits in a queue.
+- Added prompt length cap of 1000 characters for AI chat.
+
 ## [2.1.0] - 2026-5-8
 ### Added
 - AI caching.

--- a/python/bot/bot.py
+++ b/python/bot/bot.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from discord.app_commands.models import AppCommand
 
 AI_COOLDOWN: float = 5.0
+MAX_PROMPT_LENGTH: int = 1000
 
 class DizznemBot(commands.Bot):
     """Dizznem Bot class."""
@@ -228,8 +229,13 @@ class DizznemBot(commands.Bot):
 
                 self.ai_cooldowns[message.author.id] = now
                 prompt: str = message.content.replace(self.bot_tag, "").strip()
+
                 if not prompt:
                     await message.channel.send("Ask me something!")
+                elif len(prompt) > MAX_PROMPT_LENGTH:
+                    await message.channel.send(
+                        f"Your prompt is too long! Keep it under {MAX_PROMPT_LENGTH} characters.",
+                    )
                 else:
                     channel_id: int = message.channel.id
                     if channel_id not in self.cache:

--- a/python/bot/bot.py
+++ b/python/bot/bot.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import time
 from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -24,6 +25,7 @@ from utils.numbers import format_duration
 if TYPE_CHECKING:
     from discord.app_commands.models import AppCommand
 
+AI_COOLDOWN: float = 5.0
 
 class DizznemBot(commands.Bot):
     """Dizznem Bot class."""
@@ -49,6 +51,7 @@ class DizznemBot(commands.Bot):
         )
         self.ai_api_key: str = cast("str", os.getenv("AI_API_KEY", ""))
         self.cache: dict[int, deque] = {}
+        self.ai_cooldowns: dict[int, float] = {}
 
     async def setup_hook(self) -> None:
         """Load all cogs and start autosave for database."""
@@ -213,6 +216,16 @@ class DizznemBot(commands.Bot):
                 continue
 
             if trigger == self.bot_tag:
+                now: float = time.monotonic()
+                last: float = self.ai_cooldowns.get(message.author.id, 0)
+                if now - last < AI_COOLDOWN:
+                    remaining: float = AI_COOLDOWN - (now - last)
+                    await message.channel.send(
+                        f"Slow down! Try again in {remaining:.1f} seconds.",
+                    )
+                    break
+
+                self.ai_cooldowns[message.author.id] = now
                 prompt: str = message.content.replace(self.bot_tag, "").strip()
                 if not prompt:
                     await message.channel.send("Ask me something!")

--- a/python/bot/bot.py
+++ b/python/bot/bot.py
@@ -52,6 +52,7 @@ class DizznemBot(commands.Bot):
         self.ai_api_key: str = cast("str", os.getenv("AI_API_KEY", ""))
         self.cache: dict[int, deque] = {}
         self.ai_cooldowns: dict[int, float] = {}
+        self.ai_semaphore: asyncio.Semaphore = asyncio.Semaphore(3)
 
     async def setup_hook(self) -> None:
         """Load all cogs and start autosave for database."""
@@ -238,7 +239,7 @@ class DizznemBot(commands.Bot):
 
                     cache: deque = self.cache[channel_id]
 
-                    async with message.channel.typing():
+                    async with self.ai_semaphore, message.channel.typing():
                         ai_response: str = await asyncio.to_thread(
                             get_ai_response,
                             prompt,


### PR DESCRIPTION
## Describe changes

- Added per-user cooldown on AI chat to prevent spam.
- Added global semaphore limiting concurrent AI API calls to 3.
- Added prompt length cap of 1000 characters for AI chat.

## Issue number

Fixes #81

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [x] `.env.example` updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [x] Tested in Discord manually
- [x] `pytest` passes with no errors