### PR TITLE
Show canonical answer on correct ABA/Rogue trivia guess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `$summarize` now reads text embedded in messages (titles, descriptions, fields, footers), not just plain content.
 
+### Fixed
+
+- ABA/Rogue trivia now shows the correct answer even when your guess is marked correct.
+
 ## [2.2.1] - 2026-7-1
 
 ### Removed

--- a/python/bot/cogs/money/money_making.py
+++ b/python/bot/cogs/money/money_making.py
@@ -257,7 +257,7 @@ class MoneyMaking(commands.Cog):
             user.money += earnings
             embed: Embed = Embed(
                 title="✅ Correct!",
-                description=f"You won **${format_number(earnings)}**!",
+                description=f"You won **${format_number(earnings)}**!\n\nThe answer was **{answer}**.",  # noqa: E501
                 color=Color.green(),
             )
             await ctx.send(embed=embed)


### PR DESCRIPTION
## Describe changes

Shows the canonical ABA/Rogue trivia answer even after a correct guess.

- Updated `python/bot/cogs/money/money_making.py`.
  - Correct-answer embeds now include the exact wiki answer.
  - This helps users learn the official answer when fuzzy matching accepts an abbreviation, nickname, or near match.
- Updated `CHANGELOG.md`.

Incorrect-answer and timeout responses already showed the answer; this makes successful responses consistent.

## Issue number

Fixes #77

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [x] `.env.example` updated if new environment variables were added (none added)
- [x] No breaking changes to existing commands
- [ ] Tested in Discord manually
- [x] `pytest` passes with no errors
- [x] `CHANGELOG.md` updated (if applicable)