### PR TITLE
Edit trivia loading message in place instead of delete-and-resend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `$summarize` now reads text embedded in messages (titles, descriptions, fields, footers), not just plain content.
 
+### Fixed
+
+- `$aba` / `$roguelineage` no longer show "Message could not be loaded" (loading embed is edited in place instead of deleted).
+
 ## [2.2.1] - 2026-7-1
 
 ### Removed

--- a/python/bot/cogs/money/money_making.py
+++ b/python/bot/cogs/money/money_making.py
@@ -213,8 +213,7 @@ class MoneyMaking(commands.Cog):
             answer: str
             image_url, trivia_question, answer = await question(game=game)
         except aiohttp.ClientError:
-            await loading_message.delete()
-            await ctx.send(
+            await loading_message.edit(
                 embed=Embed(
                     title="⚠️ Wiki Unavailable",
                     description="Couldn't reach the wiki right now. Try again in a moment.",
@@ -222,8 +221,6 @@ class MoneyMaking(commands.Cog):
                 ),
             )
             return
-
-        await loading_message.delete()
 
         question_embed: Embed = Embed(
             title=title,
@@ -236,7 +233,7 @@ class MoneyMaking(commands.Cog):
         else:
             question_embed.set_footer(text="(No image available for this entry)")
 
-        await ctx.send(embed=question_embed)
+        await loading_message.edit(embed=question_embed)
 
         user_answer: str | None = await get_user_answer(
             bot=self.bot,


### PR DESCRIPTION
## Describe changes

Fixes ABA/Rogue trivia interactions that could show "Message could not be loaded."

- Updated `python/bot/cogs/money/money_making.py`.
  - Replaced the loading-message delete-and-resend flow with an in-place message edit.
  - The bot now edits the original loading embed into the question or error embed.
- Updated `CHANGELOG.md`.

This preserves Discord's original interaction response instead of deleting it, which was leaving broken message references in the client.

## Issue number

Fixes #74

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [x] `.env.example` updated if new environment variables were added (none added)
- [x] No breaking changes to existing commands
- [ ] Tested in Discord manually
- [x] `pytest` passes with no errors
- [x] `CHANGELOG.md` updated (if applicable)