### PR TITLE
Re-roll imageless wiki entries in ABA/Rogue trivia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `$summarize` now reads text embedded in messages (titles, descriptions, fields, footers), not just plain content.
 
+### Changed
+
+- ABA/Rogue trivia re-rolls entries with no wiki image instead of asking an unanswerable question.
+
 ## [2.2.1] - 2026-7-1
 
 ### Removed

--- a/python/utils/money/roblox.py
+++ b/python/utils/money/roblox.py
@@ -40,6 +40,7 @@ CACHE_TTL: timedelta = timedelta(hours=24)
 
 FUZZY_THRESHOLD: int = 80
 MIN_ANSWER_LENGTH: int = 4
+MAX_IMAGE_ATTEMPTS: int = 5
 
 
 class CharacterEntry(TypedDict):
@@ -290,6 +291,14 @@ async def question(game: str) -> tuple[str | None, str, str]:
 
     entry: CharacterEntry = random.choice(entries)  # noqa: S311
     image_url: str | None = await resolve_image(wiki_base, entry)
+
+    # Some wiki pages have no lead image, making the question unanswerable.
+    # Re-roll a bounded number of times before falling back to an imageless one.
+    for _ in range(MAX_IMAGE_ATTEMPTS - 1):
+        if image_url is not None:
+            break
+        entry = random.choice(entries)  # noqa: S311
+        image_url = await resolve_image(wiki_base, entry)
 
     return image_url, trivia_question, entry["name"]
 

--- a/tests/test_roblox.py
+++ b/tests/test_roblox.py
@@ -562,6 +562,65 @@ class TestQuestion:
         await question("aba")
         assert repopulate_called
 
+    async def test_retries_until_image_found(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that imageless entries are re-rolled until one with an image is found."""
+        bad: CharacterEntry = make_entry("Bad")
+        good: CharacterEntry = make_entry("Good", "https://img.example.com/good.png")
+        inject_cache("aba", {"character": [bad, good]})
+
+        picks: list[CharacterEntry] = [bad, bad, good]
+
+        def fake_choice(_seq: list) -> CharacterEntry:
+            return picks.pop(0)
+
+        async def fake_ensure(game: str) -> None:
+            pass
+
+        async def fake_resolve(_wiki: str, entry: CharacterEntry) -> str | None:
+            return entry["image_url"]
+
+        monkeypatch.setattr(roblox_util.random, "choice", fake_choice)
+        monkeypatch.setattr(roblox_util, "ensure_cache", fake_ensure)
+        monkeypatch.setattr(roblox_util, "resolve_image", fake_resolve)
+
+        image_url: str | None
+        _trivia_question: str
+        answer: str
+        image_url, _trivia_question, answer = await question("aba")
+        assert answer == "Good"
+        assert image_url == "https://img.example.com/good.png"
+
+    async def test_retries_are_bounded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that re-rolls stop after MAX_IMAGE_ATTEMPTS when no images exist."""
+        bad: CharacterEntry = make_entry("Bad")
+        inject_cache("aba", {"character": [bad]})
+
+        resolve_calls: int = 0
+
+        async def fake_ensure(game: str) -> None:
+            pass
+
+        async def fake_resolve(_wiki: str, _entry: CharacterEntry) -> None:
+            nonlocal resolve_calls
+            resolve_calls += 1
+            return None
+
+        monkeypatch.setattr(roblox_util, "ensure_cache", fake_ensure)
+        monkeypatch.setattr(roblox_util, "resolve_image", fake_resolve)
+
+        image_url: str | None
+        _trivia_question: str
+        _answer: str
+        image_url, _trivia_question, _answer = await question("aba")
+        assert image_url is None
+        assert resolve_calls == roblox_util.MAX_IMAGE_ATTEMPTS
+
     async def test_none_image_url_is_allowed(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Describe changes

Avoids serving unanswerable ABA/Rogue trivia questions when the wiki entry has no image.

- Updated `python/utils/money/roblox.py`.
  - Retries a bounded number of random entries when an entry has no image.
  - Keeps the existing no-image fallback if no usable image can be found.
- Updated `tests/test_roblox.py`.
  - Added tests for skipping imageless entries.
  - Added coverage for the bounded retry limit and fallback behavior.
- Updated `CHANGELOG.md`.

The retry limit prevents an infinite loop while substantially reducing no-image trivia questions.

## Issue number

Fixes #79

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [x] `.env.example` updated if new environment variables were added (none added)
- [x] No breaking changes to existing commands
- [ ] Tested in Discord manually
- [x] `pytest` passes with no errors
- [x] `CHANGELOG.md` updated (if applicable)