### PR TITLE
Add $steal command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - `$summarize` now reads text embedded in messages (titles, descriptions, fields, footers), not just plain content.
 
+## [Unreleased]
+
+### Added
+
+- `$steal` command — attempt to steal money from another user (40% success chance, cooldown, minimum target balance).
+
 ## [2.2.1] - 2026-7-1
 
 ### Removed

--- a/python/bot/cogs/money/money_making.py
+++ b/python/bot/cogs/money/money_making.py
@@ -5,12 +5,13 @@ from typing import Final
 
 import aiohttp
 from bot.bot import DizznemBot
-from discord import Color, Embed, Message
+from discord import Color, Embed, Member, Message
 from discord.ext import commands
 from log import logger  # noqa: F401
 from user import User
 from utils.general import get_user_answer, reset_cd
 from utils.money.roblox import check_answer, question
+from utils.money.steal import MIN_TARGET_BALANCE, resolve_steal
 from utils.money.trivia import VALID_ANSWERS, build_trivia_embed, get_random_question
 from utils.numbers import convert_money_str, format_number
 
@@ -181,6 +182,73 @@ class MoneyMaking(commands.Cog):
                 title="💎 JACKPOT!",
                 color=Color.gold(),
                 description=f"You hit the jackpot and won **${formatted_winnings}**!",
+            )
+
+        await ctx.send(embed=embed)
+
+    @commands.hybrid_command(
+        name="steal",
+        description="Attempt to steal money from another user",
+    )
+    @commands.cooldown(rate=1, per=3600, type=commands.BucketType.user)
+    async def steal(self, ctx: commands.Context, member: Member) -> None:
+        """Steal command.
+
+        Args:
+            ctx (commands.Context): Context.
+            member (Member): Member to attempt to steal from.
+        """
+        if member.id == ctx.author.id:
+            reset_cd(ctx=ctx)
+            await ctx.send(
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description="You cannot steal from yourself.",
+                ),
+                ephemeral=True,
+            )
+            return
+
+        thief: User = User.create_if_not_exists(
+            user_id=ctx.author.id,
+            username=ctx.author.name,
+        )
+        target: User = User.create_if_not_exists(user_id=member.id, username=member.name)
+
+        if target.money < MIN_TARGET_BALANCE:
+            reset_cd(ctx=ctx)
+            await ctx.send(
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description=f"**{member.display_name}** doesn't have enough money to be worth stealing from.",  # noqa: E501
+                ),
+                ephemeral=True,
+            )
+            return
+
+        success: bool
+        amount: float
+        success, amount = resolve_steal(
+            stealer_money=thief.money,
+            target_money=target.money,
+        )
+
+        if success:
+            thief.money += amount
+            target.money -= amount
+            embed: Embed = Embed(
+                title="🕵️ Heist Successful",
+                color=Color.green(),
+                description=f"You stole **${format_number(amount)}** from **{member.display_name}**!",  # noqa: E501
+            )
+        else:
+            thief.money -= amount
+            embed: Embed = Embed(
+                title="🚨 Caught!",
+                color=Color.red(),
+                description=f"You got caught trying to steal from **{member.display_name}** and paid a **${format_number(amount)}** fine!",  # noqa: E501
             )
 
         await ctx.send(embed=embed)

--- a/python/utils/money/steal.py
+++ b/python/utils/money/steal.py
@@ -1,0 +1,31 @@
+"""Steal command utilities."""
+
+import random
+
+SUCCESS_CHANCE: float = 0.4
+MIN_TARGET_BALANCE: float = 10_000.0
+STEAL_PERCENT_RANGE: tuple[float, float] = (0.10, 0.25)
+FAIL_PENALTY_PERCENT: float = 0.10
+
+
+def resolve_steal(stealer_money: float, target_money: float) -> tuple[bool, float]:
+    """Resolve a steal attempt against a target's balance.
+
+    On success, the stealer takes a random percentage of the target's
+    money. On failure, the stealer is caught and pays a flat percentage
+    of their own money as a penalty.
+
+    Args:
+        stealer_money (float): The stealer's current balance.
+        target_money (float): The target's current balance.
+
+    Returns:
+        tuple[bool, float]: (success, amount). On success, amount is
+        moved from target to stealer. On failure, amount is deducted
+        from the stealer only.
+    """
+    if random.random() < SUCCESS_CHANCE:  # noqa: S311
+        percent: float = random.uniform(*STEAL_PERCENT_RANGE)  # noqa: S311
+        return True, round(target_money * percent, 2)
+
+    return False, round(stealer_money * FAIL_PENALTY_PERCENT, 2)

--- a/tests/test_steal.py
+++ b/tests/test_steal.py
@@ -1,0 +1,61 @@
+"""Tests for utils/money/steal.py."""
+
+import pytest
+from utils.money.steal import (
+    FAIL_PENALTY_PERCENT,
+    STEAL_PERCENT_RANGE,
+    resolve_steal,
+)
+
+
+class TestResolveSteal:
+    """Tests for resolve_steal."""
+
+    def test_success_takes_percent_of_target_money(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that a successful steal takes a percentage of the target's money."""
+        monkeypatch.setattr("utils.money.steal.random.random", lambda: 0.0)
+        monkeypatch.setattr("utils.money.steal.random.uniform", lambda *_a: 0.20)
+
+        success: bool
+        amount: float
+        success, amount = resolve_steal(stealer_money=1000.0, target_money=10_000.0)
+
+        assert success is True
+        assert amount == pytest.approx(2000.0)
+
+    def test_failure_costs_percent_of_stealer_money(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that a failed steal costs the stealer a fixed percentage of their money."""
+        monkeypatch.setattr("utils.money.steal.random.random", lambda: 0.99)
+
+        success: bool
+        amount: float
+        success, amount = resolve_steal(stealer_money=1000.0, target_money=10_000.0)
+
+        assert success is False
+        assert amount == pytest.approx(1000.0 * FAIL_PENALTY_PERCENT)
+
+    def test_success_amount_within_configured_range(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that the stolen amount always falls within STEAL_PERCENT_RANGE."""
+        monkeypatch.setattr("utils.money.steal.random.random", lambda: 0.0)
+
+        low, high = STEAL_PERCENT_RANGE
+        for _ in range(20):
+            _success, amount = resolve_steal(stealer_money=500.0, target_money=1000.0)
+            assert low * 1000.0 <= amount <= high * 1000.0
+
+    def test_returns_rounded_amount(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that returned amounts are rounded to 2 decimal places."""
+        monkeypatch.setattr("utils.money.steal.random.random", lambda: 0.0)
+        monkeypatch.setattr("utils.money.steal.random.uniform", lambda *_a: 0.123456)
+
+        _success, amount = resolve_steal(stealer_money=1000.0, target_money=333.333)
+        assert amount == round(amount, 2)


### PR DESCRIPTION
40% success chance: on success, steals 10-25% of the target's balance; on failure, the stealer pays a 10% penalty of their own money. 1-hour cooldown, can't target yourself, target needs a minimum balance to be worth stealing from. Fixes #45.

## Describe changes

Adds a risk/reward economy command that lets users attempt to steal from another member.

- Added `python/utils/money/steal.py`
  - Contains the isolated steal-result logic and constants.
  - Uses a 40% success chance.
  - Successful steals take 10–25% of the target’s balance.
  - Failed attempts charge the thief a 10% penalty of their own balance.
- Updated `python/bot/cogs/money/money_making.py`
  - Added `$steal <member>`.
  - Added a one-hour per-user cooldown.
  - Prevents users from targeting themselves.
  - Prevents attempts against targets below the minimum stealable balance.
  - Sends success/failure results as embeds.
- Added `tests/test_steal.py`
  - Covers successful steals, failed steals, balance limits, and invalid targets.
- Updated `CHANGELOG.md`.

## Issue number

Fixes #

## Checklist
- [ ] No tokens, API keys, or secrets are hardcoded
- [ ] `.env.example` updated if new environment variables were added
- [ ] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [ ] `pytest` passes with no errors
- [ ] `CHANGELOG.md` updated (if applicable)