### PR TITLE
Make input/access error messages visible only to the invoking user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `$summarize` now reads text embedded in messages (titles, descriptions, fields, footers), not just plain content.
 
+### Changed
+
+- Error messages (invalid input, no access, insufficient funds) are now only visible to the user who ran the command (slash commands only).
+
 ## [2.2.1] - 2026-7-1
 
 ### Removed

--- a/python/bot/cogs/misc/admin.py
+++ b/python/bot/cogs/misc/admin.py
@@ -49,6 +49,7 @@ class Admin(commands.Cog):
                     color=Color.red(),
                     description="You do not have access to this command.",
                 ),
+                ephemeral=True,
             )
             return
 
@@ -61,6 +62,7 @@ class Admin(commands.Cog):
                     color=Color.red(),
                     description="Invalid money format.",
                 ),
+                ephemeral=True,
             )
             return
 
@@ -101,7 +103,7 @@ class Admin(commands.Cog):
                 color=Color.red(),
                 description="You do not have access to this command.",
             )
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, ephemeral=True)
             return
 
         try:
@@ -113,6 +115,7 @@ class Admin(commands.Cog):
                     color=Color.red(),
                     description="Invalid money format.",
                 ),
+                ephemeral=True,
             )
             return
 
@@ -151,6 +154,7 @@ class Admin(commands.Cog):
                     color=Color.red(),
                     description="You do not have access to this command.",
                 ),
+                ephemeral=True,
             )
             return
 
@@ -162,6 +166,7 @@ class Admin(commands.Cog):
                     color=Color.red(),
                     description=f"Command **{command_name}** not found.",
                 ),
+                ephemeral=True,
             )
             return
 

--- a/python/bot/cogs/money/money.py
+++ b/python/bot/cogs/money/money.py
@@ -83,6 +83,7 @@ class Money(commands.Cog):
                     color=Color.red(),
                     description="Invalid money format.",
                 ),
+                ephemeral=True,
             )
             return
 
@@ -93,7 +94,7 @@ class Money(commands.Cog):
                 color=Color.red(),
                 description="Amount must be greater than 0.",
             )
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, ephemeral=True)
             return
 
         MAX_TRANSFER_AMOUNT: Final[int] = 5_000_000
@@ -105,7 +106,7 @@ class Money(commands.Cog):
                 color=Color.red(),
                 description="Amount must be less than or equal to 5 Million.",
             )
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, ephemeral=True)
             return
 
         if member.id == ctx.author.id:
@@ -116,6 +117,7 @@ class Money(commands.Cog):
                     color=Color.red(),
                     description="You cannot give money to yourself.",
                 ),
+                ephemeral=True,
             )
             return
 
@@ -138,7 +140,7 @@ class Money(commands.Cog):
                 color=Color.red(),
                 description="You do not have enough money to send this amount.",
             )
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, ephemeral=True)
             return
 
         recipient_user: User = User.create_if_not_exists(

--- a/python/bot/cogs/money/money_making.py
+++ b/python/bot/cogs/money/money_making.py
@@ -118,7 +118,7 @@ class MoneyMaking(commands.Cog):
                 color=Color.red(),
                 description="Invalid money format.",
             )
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, ephemeral=True)
             return
 
         user_money_rounded: float = round(user.money, 2)
@@ -131,7 +131,7 @@ class MoneyMaking(commands.Cog):
                 color=Color.red(),
                 description="Gamble amount must be greater than 0.",
             )
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, ephemeral=True)
             return
 
         if user_money_rounded < gamble_amount:
@@ -141,7 +141,7 @@ class MoneyMaking(commands.Cog):
                 color=Color.red(),
                 description="You do not have enough money to gamble that amount.",
             )
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, ephemeral=True)
             return
 
         WIN: Final[int] = 400
@@ -344,6 +344,7 @@ class MoneyMaking(commands.Cog):
                     color=Color.red(),
                     description="Please answer with **a**, **b**, **c**, or **d**.",
                 ),
+                ephemeral=True,
             )
             return
 


### PR DESCRIPTION
Error embeds for invalid input, missing access, and insufficient funds in $give, $gamble, trivia answers, and admin commands are now sent ephemerally (slash invocations; prefix commands ignore the flag, same pattern the YouTube and stocks cogs already use). Game outcomes such as losses and timeouts stay public. Fixes #35.

## Describe changes
Makes private input/access errors ephemeral for slash-command users so they do not clutter the channel.

- Updated `python/bot/cogs/money/money.py`
  - Made `$give` validation errors private: invalid amounts, invalid transfer sizes, self-transfers, and insufficient funds.
- Updated `python/bot/cogs/money/money_making.py`
  - Made `$gamble` validation errors private.
  - Made invalid ABA/Rogue trivia-input errors private.
- Updated `python/bot/cogs/misc/admin.py`
  - Made admin permission and invalid-money-format errors private.
- Kept public game results, such as trivia losses and timeouts, public.
- Updated `CHANGELOG.md`.
## Issue number

Fixes #

## Checklist
- [ ] No tokens, API keys, or secrets are hardcoded
- [ ] `.env.example` updated if new environment variables were added
- [ ] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [ ] `pytest` passes with no errors
- [ ] `CHANGELOG.md` updated (if applicable)