### PR TITLE
Add interactive 1v1 Tic-Tac-Toe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `$summarize` now reads text embedded in messages (titles, descriptions, fields, footers), not just plain content.
 - `$retirestock` admin command to pay out and clear a stock's holders before its ticker is changed.
+- `$tictactoe <user>` / `$ttt <user>` for interactive 1v1 Tic-Tac-Toe games.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ python3 main.py
 | `$profile` | View your full profile |
 | `$inspiration` | Get an inspirational quote |
 | `$count` | Increment the server count |
+| `$tictactoe <user>` | Challenge someone to Tic-Tac-Toe |
 
 ---
 

--- a/python/bot/cogs/misc/games.py
+++ b/python/bot/cogs/misc/games.py
@@ -1,0 +1,172 @@
+"""Interactive Dizzle game commands."""
+
+from bot.bot import DizznemBot
+from discord import ButtonStyle, Interaction, Member, Message
+from discord.ext import commands
+from discord.ui import Button, View
+from utils.misc.tictactoe import get_winner, is_draw
+
+TIC_TAC_TOE_TIMEOUT: int = 300
+
+
+class TicTacToeButton(Button):
+    """A clickable Tic-Tac-Toe board cell."""
+
+    def __init__(self, index: int) -> None:
+        """Initialize a board cell.
+
+        Args:
+            index: The zero-based board position.
+        """
+        super().__init__(
+            label="\u200b",
+            style=ButtonStyle.secondary,
+            row=index // 3,
+        )
+        self.index: int = index
+
+    async def callback(self, interaction: Interaction) -> None:
+        """Place the current player's mark in this cell."""
+        view: TicTacToeView = self.view  # type: ignore[assignment]
+        await view.play(interaction, self)
+
+
+class TicTacToeView(View):
+    """A two-player Tic-Tac-Toe board."""
+
+    def __init__(self, player_x: Member, player_o: Member) -> None:
+        """Initialize a game board.
+
+        Args:
+            player_x: The command invoker, who plays X first.
+            player_o: The challenged player, who plays O.
+        """
+        super().__init__(timeout=TIC_TAC_TOE_TIMEOUT)
+        self.players: dict[str, Member] = {"X": player_x, "O": player_o}
+        self.board: list[str | None] = [None] * 9
+        self.current_mark: str = "X"
+        self.message: Message | None = None
+
+        for index in range(9):
+            self.add_item(TicTacToeButton(index))
+
+    @property
+    def current_player(self) -> Member:
+        """Return the player whose turn it is."""
+        return self.players[self.current_mark]
+
+    def _disable_board(self) -> None:
+        """Disable all board cells after a game ends."""
+        for child in self.children:
+            child.disabled = True  # type: ignore[union-attr]
+
+    async def play(self, interaction: Interaction, button: TicTacToeButton) -> None:
+        """Apply one legal move and update the board message.
+
+        Args:
+            interaction: The button interaction.
+            button: The selected board cell.
+        """
+        if interaction.user.id not in {player.id for player in self.players.values()}:
+            await interaction.response.send_message(
+                "This is not your Dizzle board, bro.",
+                ephemeral=True,
+            )
+            return
+        if interaction.user.id != self.current_player.id:
+            await interaction.response.send_message(
+                "Hold your horses - it is not your turn yet.",
+                ephemeral=True,
+            )
+            return
+        if self.board[button.index] is not None:
+            await interaction.response.send_message(
+                "That square is already claimed.",
+                ephemeral=True,
+            )
+            return
+
+        self.board[button.index] = self.current_mark
+        button.label = self.current_mark
+        button.style = ButtonStyle.success if self.current_mark == "X" else ButtonStyle.danger
+        button.disabled = True
+
+        winner: str | None = get_winner(self.board)
+        if winner is not None:
+            self._disable_board()
+            await interaction.response.edit_message(
+                content=f"{self.players[winner].mention} wins. Dizzle certified.",
+                view=self,
+            )
+            return
+        if is_draw(self.board):
+            self._disable_board()
+            await interaction.response.edit_message(
+                content="It is a draw. Both of you cooked, apparently.",
+                view=self,
+            )
+            return
+
+        self.current_mark = "O" if self.current_mark == "X" else "X"
+        await interaction.response.edit_message(
+            content=f"{self.current_player.mention}'s turn ({self.current_mark}).",
+            view=self,
+        )
+
+    async def on_timeout(self) -> None:
+        """Disable the board after five minutes of inactivity."""
+        self._disable_board()
+        if self.message is not None:
+            await self.message.edit(
+                content="Tic-Tac-Toe timed out. The board has been retired.",
+                view=self,
+            )
+
+
+class Games(commands.Cog):
+    """Interactive Dizzle game commands."""
+
+    def __init__(self, bot: DizznemBot) -> None:
+        """Initialize Games.
+
+        Args:
+            bot: The Dizznem Bot instance.
+        """
+        self.bot: DizznemBot = bot
+
+    @commands.hybrid_command(
+        name="tictactoe",
+        description="Challenge someone to Tic-Tac-Toe",
+        aliases=["ttt"],
+    )
+    async def tictactoe(self, ctx: commands.Context, opponent: Member) -> None:
+        """Start a Tic-Tac-Toe game.
+
+        Args:
+            ctx: The command context.
+            opponent: The member challenged to play O.
+        """
+        if opponent.id == ctx.author.id:
+            await ctx.send("You cannot challenge yourself.", ephemeral=True)
+            return
+        if opponent.bot:
+            await ctx.send("Bots do not play Tic-Tac-Toe. They have scripts to write.", ephemeral=True)
+            return
+
+        player_x: Member = ctx.author  # type: ignore[assignment]
+        view: TicTacToeView = TicTacToeView(player_x, opponent)
+        message: Message = await ctx.send(
+            f"{player_x.mention} is X. {opponent.mention} is O. "
+            f"{player_x.mention}'s turn (X).",
+            view=view,
+        )
+        view.message = message
+
+
+async def setup(bot: DizznemBot) -> None:
+    """Load the Games cog.
+
+    Args:
+        bot: The Dizznem Bot instance.
+    """
+    await bot.add_cog(Games(bot))

--- a/python/utils/misc/tictactoe.py
+++ b/python/utils/misc/tictactoe.py
@@ -1,0 +1,40 @@
+"""Tic-Tac-Toe game helpers."""
+
+WINNING_LINES: tuple[tuple[int, int, int], ...] = (
+    (0, 1, 2),
+    (3, 4, 5),
+    (6, 7, 8),
+    (0, 3, 6),
+    (1, 4, 7),
+    (2, 5, 8),
+    (0, 4, 8),
+    (2, 4, 6),
+)
+
+
+def get_winner(board: list[str | None]) -> str | None:
+    """Return the winning mark, if a player has completed a line.
+
+    Args:
+        board: Nine board cells containing "X", "O", or None.
+
+    Returns:
+        The winning mark, or None when no player has won.
+    """
+    for first, second, third in WINNING_LINES:
+        mark: str | None = board[first]
+        if mark is not None and mark == board[second] == board[third]:
+            return mark
+    return None
+
+
+def is_draw(board: list[str | None]) -> bool:
+    """Return whether a board is full with no winner.
+
+    Args:
+        board: Nine board cells containing "X", "O", or None.
+
+    Returns:
+        True when every cell is occupied and neither player has won.
+    """
+    return all(cell is not None for cell in board) and get_winner(board) is None

--- a/tests/test_tictactoe.py
+++ b/tests/test_tictactoe.py
@@ -1,0 +1,38 @@
+"""Tests for Tic-Tac-Toe game helpers."""
+
+import pytest
+from utils.misc.tictactoe import get_winner, is_draw
+
+
+@pytest.mark.parametrize(
+    ("board", "winner"),
+    [
+        (["X", "X", "X", None, None, None, None, None, None], "X"),
+        ([None, None, None, "O", "O", "O", None, None, None], "O"),
+        (["X", None, None, "X", None, None, "X", None, None], "X"),
+        (["O", None, None, None, "O", None, None, None, "O"], "O"),
+    ],
+)
+def test_get_winner_returns_completed_line(
+    board: list[str | None],
+    winner: str,
+) -> None:
+    """Rows, columns, and diagonals produce a winner."""
+    assert get_winner(board) == winner
+
+
+def test_get_winner_returns_none_without_completed_line() -> None:
+    """An unfinished board has no winner."""
+    assert get_winner(["X", "O", None, None, None, None, None, None, None]) is None
+
+
+def test_is_draw_requires_full_board_without_winner() -> None:
+    """A full non-winning board is a draw."""
+    board: list[str | None] = ["X", "O", "X", "X", "O", "O", "O", "X", "X"]
+    assert is_draw(board) is True
+
+
+def test_is_draw_rejects_winning_board() -> None:
+    """A full board with a winner is not a draw."""
+    board: list[str | None] = ["X", "X", "X", "O", "O", "X", "O", "X", "O"]
+    assert is_draw(board) is False


### PR DESCRIPTION
## Describe changes

Adds interactive 1v1 Tic-Tac-Toe so the community can run a quick Dizzle board game without relying on another bot.

- Added `python/bot/cogs/misc/games.py`.
  - Added `$tictactoe <user>` with `$ttt` as an alias.
  - Starts an interactive button board with the command invoker as X and the challenged member as O.
  - Enforces turn order and blocks non-players from interacting.
  - Handles wins, draws, invalid challenges, and five-minute inactive-game timeouts.
- Added `python/utils/misc/tictactoe.py`.
  - Keeps pure winner and draw detection separate from Discord UI code.
- Added `tests/test_tictactoe.py`.
  - Covers rows, columns, diagonals, no-winner boards, draws, and winning full boards.
- Updated `README.md` with the new command.
- Updated `CHANGELOG.md`.

## Issue number

Fixes #48

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [x] `.env.example` updated if new environment variables were added (none added)
- [x] No breaking changes to existing commands
- [ ] Tested in Discord manually
- [x] `pytest` passes with no errors (184 passed)
- [x] `CHANGELOG.md` updated (if applicable)