### PR TITLE
Send user feedback on unhandled command errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Unexpected command errors no longer fail silently -- you now get a "Something Went Wrong" message instead of a dead/failed interaction with no feedback.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/bot/bot.py
+++ b/python/bot/bot.py
@@ -155,6 +155,13 @@ class DizznemBot(commands.Bot):
             return
 
         else:
+            logger.error(f"Unhandled error in {ctx.command}: {error!r}")
+            embed = Embed(
+                title="⚠️ Something Went Wrong",
+                color=Color.red(),
+                description="An unexpected error occurred. Please try again.",
+            )
+            await ctx.send(embed=embed)
             raise error
 
         await ctx.send(embed=embed)


### PR DESCRIPTION
on_command_error previously re-raised unrecognized exceptions with no ctx.send, so any unexpected error (bad permissions, API hiccup, bug) left users staring at a dead/failed interaction with zero explanation. Now sends a generic error embed before re-raising, so the crash is still logged/visible to us but the user isn't left guessing.

## Describe changes

-python/bot/bot.py: on_command_error's catch-all else branch now logs the error and sends a "⚠️ Something Went Wrong" embed before re-raising (previously re-raised silently with no ctx.send, leaving users with a dead/failed interaction on any unhandled exception).
-CHANGELOG.md: added [Unreleased] entry.
-No tests added — same reasoning as the YouTube PR: nothing in this repo unit-tests Discord-object-dependent code (ctx, cogs, bot handlers), only pure utils. Ran full suite (200 passed) + ruff check (clean) to confirm no regressions.

## Issue number

Fixes #112

## Checklist
- [ ] No tokens, API keys, or secrets are hardcoded
- [ ] `.env.example` updated if new environment variables were added
- [ ] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [ ] `pytest` passes with no errors
- [ ] `CHANGELOG.md` updated (if applicable)