### PR TITLE
Fix silent YouTube playback failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `$play` no longer leaves a dead/failed interaction if the bot can't join or move to your voice channel (missing permission, timeout) -- now sends a clear error instead.
+- Playback failures (e.g. yt-dlp or ffmpeg failing to start) no longer leave the bot silently "stuck" on a song with no audio -- the failed track is now skipped with an error message and the queue continues.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/bot/cogs/misc/youtube.py
+++ b/python/bot/cogs/misc/youtube.py
@@ -9,9 +9,11 @@ from typing import TYPE_CHECKING
 import yt_dlp
 from bot.bot import DizznemBot
 from discord import (
+    ClientException,
     Color,
     Embed,
     FFmpegPCMAudio,
+    Forbidden,
     Member,
     PCMVolumeTransformer,
     StageChannel,
@@ -215,23 +217,18 @@ class YouTube(commands.Cog):
                     f"[yt] _start_playing: failed to start yt-dlp process: {e}",
                 )
                 self.current = None
+                await ctx.send(
+                    embed=Embed(
+                        title="⚠️ Playback Failed",
+                        color=Color.red(),
+                        description=f"Couldn't start playback for **{title}**, skipping.",
+                    ),
+                )
+                self._play_next(ctx)
                 return
 
             logger.debug(
                 f"[yt] _start_playing: yt-dlp process started | pid={proc.pid}",
-            )
-
-            source: PCMVolumeTransformer[FFmpegPCMAudio] = PCMVolumeTransformer(
-                FFmpegPCMAudio(
-                    proc.stdout,  # pyright: ignore[reportArgumentType]
-                    pipe=True,
-                    **FFMPEG_OPTIONS,
-                ),
-                volume=0.5,
-            )
-
-            logger.debug(
-                "[yt] _start_playing: FFmpegPCMAudio source created successfully",
             )
 
             def after_playing(error: Exception | None) -> None:
@@ -245,9 +242,33 @@ class YouTube(commands.Cog):
                     self.bot.loop,
                 )
 
-            logger.debug(f"[yt] calling voice_client.play() for {title!r}")
-            self.voice_client.play(source, after=after_playing)
-            logger.debug(f"[yt] voice_client.play() returned for {title!r}")
+            try:
+                source: PCMVolumeTransformer[FFmpegPCMAudio] = PCMVolumeTransformer(
+                    FFmpegPCMAudio(
+                        proc.stdout,  # pyright: ignore[reportArgumentType]
+                        pipe=True,
+                        **FFMPEG_OPTIONS,
+                    ),
+                    volume=0.5,
+                )
+                logger.debug(
+                    "[yt] _start_playing: FFmpegPCMAudio source created successfully",
+                )
+                logger.debug(f"[yt] calling voice_client.play() for {title!r}")
+                self.voice_client.play(source, after=after_playing)
+                logger.debug(f"[yt] voice_client.play() returned for {title!r}")
+            except Exception as e:  # noqa: BLE001
+                logger.error(f"[yt] _start_playing: failed to start playback: {e}")
+                self._kill_ytdlp()
+                self.current = None
+                await ctx.send(
+                    embed=Embed(
+                        title="⚠️ Playback Failed",
+                        color=Color.red(),
+                        description=f"Couldn't play **{title}**, skipping.",
+                    ),
+                )
+                self._play_next(ctx)
 
         asyncio.run_coroutine_threadsafe(_start_playing(), self.bot.loop)
         logger.debug(
@@ -367,17 +388,29 @@ class YouTube(commands.Cog):
             f"[yt] play: voice_channel={getattr(voice_channel, 'name', None)!r}",
         )
 
-        if self.voice_client is None or not self.voice_client.is_connected():
-            logger.debug("[yt] play: connecting to voice channel")
-            self.voice_client = (
-                await voice_channel.connect()  # pyright: ignore[reportOptionalMemberAccess]
+        try:
+            if self.voice_client is None or not self.voice_client.is_connected():
+                logger.debug("[yt] play: connecting to voice channel")
+                self.voice_client = (
+                    await voice_channel.connect()  # pyright: ignore[reportOptionalMemberAccess]
+                )
+                logger.debug("[yt] play: connected to voice channel")
+            elif self.voice_client.channel != voice_channel:
+                logger.debug(
+                    f"[yt] play: moving from {self.voice_client.channel!r} to {voice_channel!r}",
+                )
+                await self.voice_client.move_to(voice_channel)
+        except (TimeoutError, ClientException, Forbidden) as e:
+            logger.error(f"[yt] play: failed to join voice channel: {e}")
+            await ctx.send(
+                embed=Embed(
+                    title="❌ Couldn't Join Voice Channel",
+                    color=Color.red(),
+                    description="I couldn't connect to your voice channel. Check my "
+                    "voice permissions and try again.",
+                ),
             )
-            logger.debug("[yt] play: connected to voice channel")
-        elif self.voice_client.channel != voice_channel:
-            logger.debug(
-                f"[yt] play: moving from {self.voice_client.channel!r} to {voice_channel!r}",
-            )
-            await self.voice_client.move_to(voice_channel)
+            return
 
         self.queue.append(info)
         logger.debug(f"[yt] play: appended to queue | queue_size={len(self.queue)}")


### PR DESCRIPTION
## Describe changes

- python/bot/cogs/misc/youtube.py: wrapped voice_channel.connect()/move_to() in try/except (TimeoutError, ClientException, Forbidden), sends "Couldn't Join Voice Channel" on failure.
- python/bot/cogs/misc/youtube.py: _start_playing() now wraps yt-dlp subprocess start and FFmpegPCMAudio/play() in try/except, sends "Playback Failed" and skips to next song instead of hanging silently.
- CHANGELOG.md: added [Unreleased] entry.

## Issue number

Fixes #113

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated