### PR TITLE
Fix #110: ABA / Rogue Image Still Not Showing Up Sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `$aba` / `$rogue` still occasionally showing no image (#110) -- wiki pages confirmed to have no image are now excluded from future picks entirely (previously they could still be re-picked and re-rolled into every trivia round, occasionally exhausting all re-roll attempts).
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/utils/money/roblox.py
+++ b/python/utils/money/roblox.py
@@ -48,6 +48,7 @@ class CharacterEntry(TypedDict):
 
     name: str
     image_url: str | None
+    confirmed_no_image: bool
 
 
 class GameCache(TypedDict):
@@ -187,7 +188,7 @@ def build_entries(wiki_base: str, category: str) -> list[CharacterEntry]:
     """
     titles: list[str] = fetch_category_members(wiki_base, category)
     return [
-        CharacterEntry(name=t, image_url=None)
+        CharacterEntry(name=t, image_url=None, confirmed_no_image=False)
         for t in titles
         if t not in _CATEGORY_PAGE_FILTER
     ]
@@ -228,7 +229,8 @@ def resolve_image_blocking(wiki_base: str, entry: CharacterEntry) -> str | None:
     """Fetch and cache the image URL for a single entry if not already set.
 
     Mutates entry["image_url"] in place so the same character skips the
-    API call on subsequent picks.
+    API call on subsequent picks. Pages confirmed to have no image are
+    flagged via confirmed_no_image so they're not re-fetched every pick.
 
     Args:
         wiki_base (str): Base URL of the wiki.
@@ -237,8 +239,10 @@ def resolve_image_blocking(wiki_base: str, entry: CharacterEntry) -> str | None:
     Returns:
         str | None: The image URL, or None if none found.
     """
-    if entry["image_url"] is None:
+    if entry["image_url"] is None and not entry["confirmed_no_image"]:
         entry["image_url"] = fetch_image_url(wiki_base, entry["name"])
+        if entry["image_url"] is None:
+            entry["confirmed_no_image"] = True
     return entry["image_url"]
 
 
@@ -289,15 +293,24 @@ async def question(game: str) -> tuple[str | None, str, str]:
         msg: str = f"No entries found for category {category_key!r}"
         raise RuntimeError(msg)
 
-    entry: CharacterEntry = random.choice(entries)  # noqa: S311
+    def pickable_pool() -> list[CharacterEntry]:
+        """Entries not yet confirmed imageless, falling back to all entries."""
+        pool: list[CharacterEntry] = [
+            e for e in entries if not e["confirmed_no_image"]
+        ]
+        return pool or entries
+
+    entry: CharacterEntry = random.choice(pickable_pool())  # noqa: S311
     image_url: str | None = await resolve_image(wiki_base, entry)
 
     # Some wiki pages have no lead image, making the question unanswerable.
     # Re-roll a bounded number of times before falling back to an imageless one.
+    # Entries confirmed imageless are excluded from the pool as they're found,
+    # so they won't be picked again for the life of this cache entry.
     for _ in range(MAX_IMAGE_ATTEMPTS - 1):
         if image_url is not None:
             break
-        entry = random.choice(entries)  # noqa: S311
+        entry = random.choice(pickable_pool())  # noqa: S311
         image_url = await resolve_image(wiki_base, entry)
 
     return image_url, trivia_question, entry["name"]

--- a/tests/test_roblox.py
+++ b/tests/test_roblox.py
@@ -22,17 +22,26 @@ from utils.money.roblox import (
 )
 
 
-def make_entry(name: str, image_url: str | None = None) -> CharacterEntry:
+def make_entry(
+    name: str,
+    image_url: str | None = None,
+    confirmed_no_image: bool = False,
+) -> CharacterEntry:
     """Create a CharacterEntry for testing.
 
     Args:
         name (str): Character name.
         image_url (str | None): Optional image URL.
+        confirmed_no_image (bool): Whether the entry is confirmed imageless.
 
     Returns:
         CharacterEntry: Test entry.
     """
-    return CharacterEntry(name=name, image_url=image_url)
+    return CharacterEntry(
+        name=name,
+        image_url=image_url,
+        confirmed_no_image=confirmed_no_image,
+    )
 
 
 def inject_cache(game: str, data: dict, age: timedelta = timedelta(hours=0)) -> None:
@@ -391,6 +400,33 @@ class TestResolveImageBlocking:
         assert result is None
         assert entry["image_url"] is None
 
+    def test_marks_confirmed_no_image_on_miss(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that a page with no thumbnail is flagged as confirmed_no_image."""
+        entry: CharacterEntry = make_entry("Unnamed")
+        monkeypatch.setattr(roblox_util, "fetch_image_url", lambda *_a: None)
+        resolve_image_blocking("https://example.fandom.com", entry)
+        assert entry["confirmed_no_image"] is True
+
+    def test_skips_fetch_when_confirmed_no_image(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that a confirmed-imageless entry is never re-fetched."""
+        entry: CharacterEntry = make_entry("Unnamed", confirmed_no_image=True)
+        called: bool = False
+
+        def should_not_be_called(*_a: object) -> None:
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr(roblox_util, "fetch_image_url", should_not_be_called)
+        result: str | None = resolve_image_blocking("https://example.fandom.com", entry)
+        assert result is None
+        assert not called
+
 
 class TestPopulateCacheBlocking:
     """Tests for populate_cache_blocking."""
@@ -592,6 +628,74 @@ class TestQuestion:
         image_url, _trivia_question, answer = await question("aba")
         assert answer == "Good"
         assert image_url == "https://img.example.com/good.png"
+
+    async def test_confirmed_no_image_entries_excluded_from_pool(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that already-confirmed-imageless entries are never picked."""
+        bad: CharacterEntry = make_entry("Bad", confirmed_no_image=True)
+        good: CharacterEntry = make_entry(
+            "Good",
+            "https://img.example.com/good.png",
+        )
+        inject_cache("aba", {"character": [bad, good]})
+
+        pools_seen: list[list[str]] = []
+
+        def fake_choice(seq: list) -> CharacterEntry:
+            pools_seen.append([e["name"] for e in seq])
+            return seq[0]
+
+        async def fake_ensure(game: str) -> None:
+            pass
+
+        async def fake_resolve(_wiki: str, entry: CharacterEntry) -> str | None:
+            return entry["image_url"]
+
+        monkeypatch.setattr(roblox_util.random, "choice", fake_choice)
+        monkeypatch.setattr(roblox_util, "ensure_cache", fake_ensure)
+        monkeypatch.setattr(roblox_util, "resolve_image", fake_resolve)
+
+        await question("aba")
+
+        assert all("Bad" not in pool for pool in pools_seen)
+
+    async def test_pool_excludes_freshly_confirmed_entry_on_reroll(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that an entry confirmed imageless mid-call is excluded on reroll."""
+        bad: CharacterEntry = make_entry("Bad")
+        good: CharacterEntry = make_entry(
+            "Good",
+            "https://img.example.com/good.png",
+        )
+        inject_cache("aba", {"character": [bad, good]})
+
+        pools_seen: list[list[str]] = []
+        picks: list[CharacterEntry] = [bad, good]
+
+        def fake_choice(seq: list) -> CharacterEntry:
+            pools_seen.append([e["name"] for e in seq])
+            return picks.pop(0)
+
+        async def fake_ensure(game: str) -> None:
+            pass
+
+        async def fake_resolve(_wiki: str, entry: CharacterEntry) -> str | None:
+            if entry["image_url"] is None:
+                entry["confirmed_no_image"] = True
+            return entry["image_url"]
+
+        monkeypatch.setattr(roblox_util.random, "choice", fake_choice)
+        monkeypatch.setattr(roblox_util, "ensure_cache", fake_ensure)
+        monkeypatch.setattr(roblox_util, "resolve_image", fake_resolve)
+
+        await question("aba")
+
+        assert pools_seen[0] == ["Bad", "Good"]
+        assert pools_seen[1] == ["Good"]
 
     async def test_retries_are_bounded(
         self,


### PR DESCRIPTION
## Describe changes

- python/utils/money/roblox.py: Added `confirmed_no_image` field to `CharacterEntry`. `resolve_image_blocking()` now sets it when a wiki page has no thumbnail, and skips re-fetching entries already confirmed imageless.
- python/utils/money/roblox.py: `question()` now filters the pick pool to exclude confirmed-imageless entries before every `random.choice()` (initial pick and each re-roll), so a bad wiki page is discovered once per 24h cache cycle and never picked again -- previously it could be re-picked (and re-fetched) on any future round, occasionally exhausting all 5 re-roll attempts.
- python/utils/money/roblox.py: `build_entries()` now initializes `confirmed_no_image=False` on new entries.
- tests/test_roblox.py: updated `make_entry()` helper to accept `confirmed_no_image`; added 4 new tests (flag set on miss, fetch skipped once confirmed, confirmed entries excluded from pool, pool shrinks mid-call after a fresh miss).
- CHANGELOG.md: added [Unreleased] entry.

Verified against the live wikis that several category pages (e.g. Doflamingo, Ascended Vind, Askarian) genuinely have no page image at all -- not a redirect or API param issue.

## Issue number

Fixes #110

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated (if applicable)