### PR TITLE
Group $help commands into categories, hide admin commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `$help` now groups commands into categories (💰 Economy, 🎵 Music, 🎮 Games, 👤 Profile, 🤖 AI, ℹ️ Misc) instead of one flat alphabetical list, and admin-only commands are hidden unless you're the bot admin.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/bot/cogs/misc/misc.py
+++ b/python/bot/cogs/misc/misc.py
@@ -10,7 +10,7 @@ from discord import Color, Embed, Member, TextChannel, User
 from discord.ext import commands, tasks
 from log import logger
 from utils.misc.count import ensure_count_db, increment_count
-from utils.misc.help import get_help_text
+from utils.misc.help import CATEGORY_ORDER, build_help_categories, chunk_lines
 from utils.misc.inspiration import ensure_inspiration_db, get_random_quote
 
 INSPIRATION_DB_PATH: Path = Path("data/inspiration.db")
@@ -92,12 +92,22 @@ class Misc(commands.Cog):
         Args:
             ctx (commands.Context): Context.
         """
-        help_text: str = get_help_text(ctx.bot)
+        is_admin: bool = ctx.author.id == self.bot.admin_id
+        categories: dict[str, list[str]] = build_help_categories(ctx.bot, is_admin)
+
         embed: Embed = Embed(
-            title="Commands",
+            title="📖 Commands",
             color=Color.og_blurple(),
-            description=help_text,
+            description="Here's everything I can do, organized by category.",
         )
+        for category in CATEGORY_ORDER:
+            lines: list[str] | None = categories.get(category)
+            if not lines:
+                continue
+            for i, chunk in enumerate(chunk_lines(lines)):
+                field_name: str = category if i == 0 else f"{category} (cont.)"
+                embed.add_field(name=field_name, value=chunk, inline=False)
+
         await ctx.send(embed=embed)
 
     @commands.hybrid_command(

--- a/python/utils/misc/help.py
+++ b/python/utils/misc/help.py
@@ -2,18 +2,81 @@
 
 from discord.ext import commands
 
+CATEGORY_MAP: dict[str, str] = {
+    "Money": "💰 Economy",
+    "MoneyMaking": "💰 Economy",
+    "Stocks": "💰 Economy",
+    "YouTube": "🎵 Music",
+    "Games": "🎮 Games",
+    "UserInfo": "👤 Profile",
+    "AI": "🤖 AI",
+    "Misc": "ℹ️ Misc",
+    "Admin": "🛠️ Admin",
+}
 
-def get_help_text(bot: commands.Bot) -> str:
-    """Generate help text dynamically from all loaded bot commands.
+CATEGORY_ORDER: list[str] = [
+    "💰 Economy",
+    "🎵 Music",
+    "🎮 Games",
+    "👤 Profile",
+    "🤖 AI",
+    "ℹ️ Misc",
+    "🛠️ Admin",
+]
+
+ADMIN_CATEGORY: str = "🛠️ Admin"
+MAX_FIELD_LENGTH: int = 1000
+
+
+def build_help_categories(
+    bot: commands.Bot,
+    is_admin: bool,
+) -> dict[str, list[str]]:
+    """Group bot commands into display categories.
 
     Args:
         bot (commands.Bot): The bot instance.
+        is_admin (bool): Whether to include the admin-only category.
 
     Returns:
-        str: Formatted help text.
+        dict[str, list[str]]: Category label -> list of formatted command lines.
     """
-    lines: list[str] = []
+    categories: dict[str, list[str]] = {}
     for cmd in sorted(bot.commands, key=lambda c: c.name):
+        cog_name: str = cmd.cog_name or "Misc"
+        category: str = CATEGORY_MAP.get(cog_name, "ℹ️ Misc")
+        if category == ADMIN_CATEGORY and not is_admin:
+            continue
+
         description: str = cmd.description or cmd.help or "No description."
-        lines.append(f"**${cmd.name}** — {description}")
-    return "\n".join(lines)
+        categories.setdefault(category, []).append(f"**${cmd.name}** — {description}")
+
+    return categories
+
+
+def chunk_lines(lines: list[str], max_length: int = MAX_FIELD_LENGTH) -> list[str]:
+    """Group lines into chunks that each fit within an embed field's length limit.
+
+    Args:
+        lines (list[str]): Lines to group.
+        max_length (int): Max characters per chunk.
+
+    Returns:
+        list[str]: Newline-joined chunks, each under max_length.
+    """
+    chunks: list[str] = []
+    current: list[str] = []
+    current_length: int = 0
+
+    for line in lines:
+        if current and current_length + len(line) + 1 > max_length:
+            chunks.append("\n".join(current))
+            current = []
+            current_length = 0
+        current.append(line)
+        current_length += len(line) + 1
+
+    if current:
+        chunks.append("\n".join(current))
+
+    return chunks

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,130 @@
+"""Tests for utils/misc/help.py."""
+
+from types import SimpleNamespace
+from typing import Any
+
+from utils.misc.help import ADMIN_CATEGORY, build_help_categories, chunk_lines
+
+
+def make_command(
+    name: str,
+    cog_name: str | None,
+    description: str = "A command.",
+    help_text: str | None = None,
+) -> Any:  # noqa: ANN401
+    """Create a fake discord.py command for testing.
+
+    Args:
+        name (str): Command name.
+        cog_name (str | None): Owning cog's class name.
+        description (str): Command description.
+        help_text (str | None): Fallback help text.
+
+    Returns:
+        Any: A stand-in object with the attributes build_help_categories reads.
+    """
+    return SimpleNamespace(
+        name=name,
+        cog_name=cog_name,
+        description=description,
+        help=help_text,
+    )
+
+
+def make_bot(commands_list: list[Any]) -> Any:  # noqa: ANN401
+    """Create a fake bot exposing a commands list.
+
+    Args:
+        commands_list (list[Any]): Fake commands.
+
+    Returns:
+        Any: A stand-in object with a .commands attribute.
+    """
+    return SimpleNamespace(commands=commands_list)
+
+
+class TestBuildHelpCategories:
+    """Tests for build_help_categories."""
+
+    def test_groups_by_category(self) -> None:
+        """Test that commands are grouped into their mapped category."""
+        bot: Any = make_bot(
+            [
+                make_command("daily", "MoneyMaking"),
+                make_command("play", "YouTube"),
+            ],
+        )
+        categories: dict[str, list[str]] = build_help_categories(bot, is_admin=False)
+        assert any("daily" in line for line in categories["💰 Economy"])
+        assert any("play" in line for line in categories["🎵 Music"])
+
+    def test_unknown_cog_falls_back_to_misc(self) -> None:
+        """Test that commands from an unmapped cog land in Misc."""
+        bot: Any = make_bot([make_command("mystery", "SomeNewCog")])
+        categories: dict[str, list[str]] = build_help_categories(bot, is_admin=False)
+        assert any("mystery" in line for line in categories["ℹ️ Misc"])
+
+    def test_admin_category_hidden_for_non_admin(self) -> None:
+        """Test that admin commands are excluded for non-admins."""
+        bot: Any = make_bot([make_command("addmoney", "Admin")])
+        categories: dict[str, list[str]] = build_help_categories(bot, is_admin=False)
+        assert ADMIN_CATEGORY not in categories
+
+    def test_admin_category_shown_for_admin(self) -> None:
+        """Test that admin commands are included for admins."""
+        bot: Any = make_bot([make_command("addmoney", "Admin")])
+        categories: dict[str, list[str]] = build_help_categories(bot, is_admin=True)
+        assert any("addmoney" in line for line in categories[ADMIN_CATEGORY])
+
+    def test_uses_help_as_description_fallback(self) -> None:
+        """Test that .help is used when .description is empty."""
+        bot: Any = make_bot(
+            [make_command("foo", "Misc", description="", help_text="Help text.")],
+        )
+        categories: dict[str, list[str]] = build_help_categories(bot, is_admin=False)
+        assert "Help text." in categories["ℹ️ Misc"][0]
+
+    def test_uses_no_description_fallback(self) -> None:
+        """Test that a generic fallback is used with no description or help."""
+        bot: Any = make_bot([make_command("foo", "Misc", description="")])
+        categories: dict[str, list[str]] = build_help_categories(bot, is_admin=False)
+        assert "No description." in categories["ℹ️ Misc"][0]
+
+    def test_sorted_alphabetically(self) -> None:
+        """Test that commands within a category are alphabetically sorted."""
+        bot: Any = make_bot(
+            [make_command("zeta", "Misc"), make_command("alpha", "Misc")],
+        )
+        categories: dict[str, list[str]] = build_help_categories(bot, is_admin=False)
+        names: list[str] = categories["ℹ️ Misc"]
+        assert names[0].startswith("**$alpha**")
+        assert names[1].startswith("**$zeta**")
+
+    def test_no_cog_falls_back_to_misc(self) -> None:
+        """Test that a command with no cog lands in Misc."""
+        bot: Any = make_bot([make_command("orphan", None)])
+        categories: dict[str, list[str]] = build_help_categories(bot, is_admin=False)
+        assert any("orphan" in line for line in categories["ℹ️ Misc"])
+
+
+class TestChunkLines:
+    """Tests for chunk_lines."""
+
+    def test_single_chunk_when_short(self) -> None:
+        """Test that short lines are combined into a single chunk."""
+        assert chunk_lines(["a", "b", "c"], max_length=1000) == ["a\nb\nc"]
+
+    def test_splits_when_exceeding_max_length(self) -> None:
+        """Test that lines are split once the max length would be exceeded."""
+        lines: list[str] = ["x" * 60, "y" * 60]
+        chunks: list[str] = chunk_lines(lines, max_length=100)
+        assert chunks == ["x" * 60, "y" * 60]
+
+    def test_empty_list_returns_empty(self) -> None:
+        """Test that an empty input returns an empty output."""
+        assert chunk_lines([]) == []
+
+    def test_oversized_single_line_kept_alone(self) -> None:
+        """Test that a single line longer than max_length isn't dropped or split."""
+        line: str = "z" * 200
+        assert chunk_lines([line], max_length=100) == [line]


### PR DESCRIPTION
## Describe changes

- python/utils/misc/help.py: Replaced the old flat `get_help_text()` with `build_help_categories()` (groups commands by cog into labeled categories -- Economy, Music, Games, Profile, AI, Misc, Admin -- and drops the Admin category entirely for non-admins) and `chunk_lines()` (splits a category's command list into chunks under Discord's per-field character limit, same pattern already used in youtube.py's queue command).
- python/bot/cogs/misc/misc.py: `$help` now builds one embed field per category (chunked as needed) instead of one giant description string, and checks `ctx.author.id == self.bot.admin_id` to decide whether to include the Admin category.
- tests/test_help.py: new test file, 8 tests covering category grouping, unknown-cog fallback to Misc, admin category shown/hidden, description/help fallback text, alphabetical sort within a category, and line chunking behavior.
- CHANGELOG.md: added [Unreleased] entry.

Verified the full real command list (35 commands across 8 cogs) maps correctly: 31 shown to regular users, all 35 shown to the admin, nothing dropped or duplicated.

## Issue number

Fixes #N/A (self-identified UX improvement, no filed issue)

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated (if applicable)