### PR TITLE
Improve $gamble error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `$gamble` error messages are more helpful: an invalid amount now shows example formats (`500`, `1,000`, `$250`, `all`, `half`), and trying to gamble more than you have now shows your actual balance instead of just saying "not enough money."
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/bot/cogs/money/money_making.py
+++ b/python/bot/cogs/money/money_making.py
@@ -115,9 +115,13 @@ class MoneyMaking(commands.Cog):
         except ValueError:
             reset_cd(ctx=ctx)
             embed: Embed = Embed(
-                title="Error",
+                title="❌ Invalid Amount",
                 color=Color.red(),
-                description="Invalid money format.",
+                description=(
+                    f"**{amount}** isn't a valid amount.\n\n"
+                    "Try a number like `500`, `1,000`, or `$250` — "
+                    "or use `all` / `half`."
+                ),
             )
             await ctx.send(embed=embed, ephemeral=True)
             return
@@ -138,9 +142,12 @@ class MoneyMaking(commands.Cog):
         if user_money_rounded < gamble_amount:
             reset_cd(ctx=ctx)
             embed: Embed = Embed(
-                title="Error",
+                title="❌ Not Enough Money",
                 color=Color.red(),
-                description="You do not have enough money to gamble that amount.",
+                description=(
+                    f"You only have **${format_number(user_money_rounded)}** "
+                    f"but tried to gamble **${format_number(gamble_amount)}**."
+                ),
             )
             await ctx.send(embed=embed, ephemeral=True)
             return


### PR DESCRIPTION
Invalid-amount and insufficient-funds errors were dead ends -- neither told the user what to do about it. Now shows example valid formats (500, 1,000, $250, all, half) on a bad amount, and shows the user's actual balance when they try to gamble more than they have.

## Describe changes

python/bot/cogs/money/money_making.py, gamble():
Invalid-amount error (except ValueError block): title changed from generic "Error" to "❌ Invalid Amount"; description now shows the exact invalid input back to the user and lists valid formats (500, 1,000, $250, all, half) instead of just saying "Invalid money format."
Insufficient-funds error (user_money_rounded < gamble_amount block): title changed from "Error" to "❌ Not Enough Money"; description now shows the user's actual current balance alongside the amount they tried to gamble, using the already-imported format_number helper — no new imports needed.
CHANGELOG.md: added [Unreleased] → ### Changed entry describing both message improvements.
No automated tests added — consistent with the rest of this session's cog-level fixes, this repo has no precedent for unit-testing Discord command code (only pure utils are tested). Ran the full suite (200 passed) and ruff check (clean) to confirm no regressions.
## Issue number

Fixes # self-identified via UX audit, not a bug report

## Checklist
- [ ] No tokens, API keys, or secrets are hardcoded
- [ ] `.env.example` updated if new environment variables were added
- [ ] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [ ] `pytest` passes with no errors
- [ ] `CHANGELOG.md` updated (if applicable)