### PR TITLE
Fix /networth requiring a member argument to check your own net worth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `/networth` and `$networth` required you to tag a member even to check your own net worth -- now works with no argument, matching `/balance`.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/bot/cogs/money/money.py
+++ b/python/bot/cogs/money/money.py
@@ -163,7 +163,11 @@ class Money(commands.Cog):
         name="networth",
         description="Get your net worth",
     )
-    async def networth(self, ctx: commands.Context, member: Member | None) -> None:
+    async def networth(
+        self,
+        ctx: commands.Context,
+        member: Member | None = None,
+    ) -> None:
         """Net worth command.
 
         Args:

--- a/tests/test_money_cog.py
+++ b/tests/test_money_cog.py
@@ -1,0 +1,21 @@
+"""Regression tests for bot/cogs/money/money.py command signatures."""
+
+import inspect
+
+from bot.cogs.money.money import Money
+
+
+class TestNetworthSignature:
+    """Tests for the /networth command's parameter defaults."""
+
+    def test_member_defaults_to_none(self) -> None:
+        """member must default to None so /networth works with no argument.
+
+        Regression test: member previously had no default, making the
+        member argument required for both the slash command and $networth,
+        so a user couldn't check their own net worth without tagging
+        themselves. See /balance for the correct pattern.
+        """
+        sig: inspect.Signature = inspect.signature(Money.networth.callback)
+        member_param: inspect.Parameter = sig.parameters["member"]
+        assert member_param.default is None


### PR DESCRIPTION
## Describe changes

- python/bot/cogs/money/money.py: `networth`'s `member` parameter was `Member | None` with no default, making it required for both the slash command and `$networth` text command. Added `= None` to match the identical pattern already used by `/balance`.
- tests/test_money_cog.py: new file, one regression test asserting `member` defaults to `None` via `inspect.signature`, so this can't silently regress again.
- CHANGELOG.md: added [Unreleased] entry.

Found via signature introspection (`inspect.signature(Money.networth.callback)` showed `default=<class 'inspect._empty'>` vs `balance`'s `default=None`) -- confirmed this makes the argument required in both the slash command and text command forms, not just a type-hint cosmetic issue.

## Issue number

Fixes # self identified bug

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated (if applicable)