### PR TITLE
Fix stale-balance check in store purchases and PRESTIGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `$store` purchases and PRESTIGE could go through (and PRESTIGE could grant its reward) using a stale balance check from when the store menu was opened, instead of your current balance -- if your balance dropped while the menu was still open (e.g. from gambling), a purchase could push your balance negative, or PRESTIGE could still succeed at less than the true cost. Both now re-check your live balance right before spending it.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/utils/money/store_views.py
+++ b/python/utils/money/store_views.py
@@ -167,7 +167,11 @@ class StoreView(View):
         return embed
 
     def _check_balance(self, cost: float) -> bool:
-        """Check if the user can afford an item.
+        """Check if the user can currently afford an item.
+
+        Re-reads the live balance rather than relying on the balance the
+        view was created with, since that snapshot can go stale (e.g. the
+        user spends money elsewhere) while this view is still open.
 
         Args:
             cost (float): Item cost.
@@ -175,17 +179,18 @@ class StoreView(View):
         Returns:
             bool: True if affordable.
         """
-        return self.balance >= cost
+        user: User = User.create_if_not_exists(user_id=self.user_id, username="")
+        return user.money >= cost
 
     async def _deduct(self, cost: float) -> None:
-        """Deduct cost from user balance via User cache.
+        """Deduct cost from the user's live balance.
 
         Args:
             cost (float): Amount to deduct.
         """
         user: User = User.create_if_not_exists(user_id=self.user_id, username="")
         user.money -= cost
-        self.balance -= cost
+        self.balance = user.money
 
     async def _insufficient_funds(self, interaction: Interaction) -> None:
         """Send insufficient funds message.
@@ -482,6 +487,18 @@ class PrestigeConfirmView(View):
             _ (Button): Unused button reference.
         """
         user: User = User.create_if_not_exists(user_id=self.user_id, username="")
+        if user.money < self.cost:
+            self.stop()
+            await interaction.response.edit_message(
+                embed=Embed(
+                    title="❌ Insufficient Funds",
+                    color=Color.red(),
+                    description="Your balance changed and you can no longer afford to prestige.",  # noqa: E501
+                ),
+                view=None,
+            )
+            return
+
         user.money = 0
         user.prestige += 1
 

--- a/tests/test_store_views.py
+++ b/tests/test_store_views.py
@@ -1,0 +1,144 @@
+"""Tests for utils/money/store_views.py."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from user import User
+from utils.money.stocks import ensure_stocks_tables
+from utils.money.store_views import PrestigeConfirmView, StoreView
+
+
+@pytest.fixture
+def db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Set up a temporary users database with a fresh user cache."""
+    db_path: Path = tmp_path / "users.db"
+
+    monkeypatch.setattr("user.DB_PATH", db_path)
+    monkeypatch.setattr("user.USER_CACHE", {})
+    monkeypatch.setattr("utils.money.store_views.USERS_DB_PATH", db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                money REAL DEFAULT 0,
+                prestige INTEGER DEFAULT 0,
+                level INTEGER DEFAULT 0,
+                message_count INTEGER DEFAULT 0
+            )
+            """,
+        )
+
+    ensure_stocks_tables(db_path)
+    return db_path
+
+
+class TestStoreViewCheckBalance:
+    """Tests for StoreView._check_balance."""
+
+    def test_uses_live_balance_not_stale_snapshot(self, db: Path) -> None:
+        """Test that a low live balance fails the check despite a rich snapshot."""
+        user: User = User.create_if_not_exists(user_id=1, username="test")
+        user.money = 5
+        view: StoreView = StoreView(user_id=1, balance=999_999, prestige=0, bot=None)
+        assert view._check_balance(10_000) is False  # noqa: SLF001
+
+    def test_passes_when_live_balance_covers_cost(self, db: Path) -> None:
+        """Test that a sufficient live balance passes the check."""
+        user: User = User.create_if_not_exists(user_id=2, username="test")
+        user.money = 50_000
+        view: StoreView = StoreView(user_id=2, balance=0, prestige=0, bot=None)
+        assert view._check_balance(10_000) is True  # noqa: SLF001
+
+    def test_fails_when_live_balance_dropped_below_stale_snapshot(
+        self,
+        db: Path,
+    ) -> None:
+        """Test the exact stale-balance bug: snapshot said rich, live is now poor."""
+        user: User = User.create_if_not_exists(user_id=3, username="test")
+        user.money = 100_000
+        view: StoreView = StoreView(user_id=3, balance=100_000, prestige=0, bot=None)
+        # Balance drops elsewhere while this view is still open (e.g. gambling).
+        user.money = 1_000
+        assert view._check_balance(10_000) is False  # noqa: SLF001
+
+
+class TestStoreViewDeduct:
+    """Tests for StoreView._deduct."""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_deducts_from_live_balance(self, db: Path) -> None:
+        """Test that deduct subtracts from the user's live money, not the snapshot."""
+        user: User = User.create_if_not_exists(user_id=4, username="test")
+        user.money = 100
+        view: StoreView = StoreView(user_id=4, balance=100, prestige=0, bot=None)
+        await view._deduct(30)  # noqa: SLF001
+        assert user.money == 70  # noqa: PLR2004
+
+    async def test_deduct_cannot_be_tricked_by_stale_snapshot(self, db: Path) -> None:
+        """Test that deducting twice against a stale snapshot doesn't double count."""
+        user: User = User.create_if_not_exists(user_id=5, username="test")
+        user.money = 50
+        view: StoreView = StoreView(user_id=5, balance=999_999, prestige=0, bot=None)
+        await view._deduct(30)  # noqa: SLF001
+        assert user.money == 20  # noqa: PLR2004
+        assert view.balance == 20  # noqa: PLR2004, SLF001
+
+
+class TestPrestigeConfirmViewLiveCheck:
+    """Tests for PrestigeConfirmView's live balance re-check on confirm."""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_prestige_rejected_when_balance_dropped(self, db: Path) -> None:
+        """Test that prestige is refused if the live balance no longer covers cost."""
+        user: User = User.create_if_not_exists(user_id=6, username="test")
+        user.money = 100_000_000
+        view: PrestigeConfirmView = PrestigeConfirmView(
+            user_id=6,
+            bot=None,
+            cost=100_000_000,
+        )
+        # Balance drops below the prestige cost before confirming.
+        user.money = 1_000
+
+        class FakeResponse:
+            async def edit_message(self, **_kwargs: object) -> None:
+                pass
+
+        class FakeInteraction:
+            response = FakeResponse()
+
+        await view.confirm.callback(FakeInteraction())
+
+        assert user.money == 1_000  # noqa: PLR2004 -- unchanged, not reset to 0
+        assert user.prestige == 0
+
+    async def test_prestige_succeeds_when_balance_still_covers_cost(
+        self,
+        db: Path,
+    ) -> None:
+        """Test that prestige still works normally when the balance is sufficient."""
+        user: User = User.create_if_not_exists(user_id=7, username="test")
+        user.money = 150_000_000
+        view: PrestigeConfirmView = PrestigeConfirmView(
+            user_id=7,
+            bot=None,
+            cost=100_000_000,
+        )
+
+        class FakeResponse:
+            async def edit_message(self, **_kwargs: object) -> None:
+                pass
+
+        class FakeInteraction:
+            response = FakeResponse()
+
+        await view.confirm.callback(FakeInteraction())
+
+        assert user.money == 0
+        assert user.prestige == 1


### PR DESCRIPTION
## Describe changes

- python/utils/money/store_views.py: `StoreView._check_balance()` now re-reads the user's live balance from the User cache instead of comparing against `self.balance`, a snapshot taken when the `/store` menu was first opened. `StoreView._deduct()` now also deducts from and re-syncs `self.balance` off the live value.
- python/utils/money/store_views.py: `PrestigeConfirmView.confirm()` now re-checks the live balance against the prestige cost immediately before granting the reset+prestige reward, showing an "Insufficient Funds" message and cancelling if the balance dropped below the cost since the confirmation prompt was shown.
- tests/test_store_views.py: new test file, 7 tests -- confirms the exact bug (stale-rich-snapshot but live-poor balance is correctly rejected), confirms deduction operates on live money, and confirms the prestige confirm path both rejects on insufficient live balance and still works normally when the balance is sufficient.
- CHANGELOG.md: added [Unreleased] entry.

Root cause: the store buttons checked `self.balance` (a value captured once, at menu-open time, and only updated by this same view's own purchases) instead of the authoritative live balance. If the user's real balance dropped from something else happening concurrently (e.g. losing money on `$gamble` while the store menu was still open within its 60s timeout), the stale check would still pass and the deduction would push their live balance negative -- the same class of bug as the `$steal` fix (unchecked/stale balance math before a deduction), just surfacing in the store's button flow instead. Verified `stock_views.py`'s buy/sell buttons do NOT have this issue -- the actual money mutation there goes through `buy_stock`/`sell_stock` in `utils/money/stocks.py`, which both already re-check the live balance/holdings right before mutating, so no fix was needed there.

## Issue number

Fixes #N/A (self-identified during a reliability audit, no filed issue)

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated (if applicable)