### PR TITLE
Stop wiping the log file on every restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- The log file was wiped every time the bot restarted, destroying the exact evidence needed to diagnose whatever crash caused the restart. Logs now append instead of overwrite.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/log.py
+++ b/python/log.py
@@ -17,7 +17,7 @@ def set_up_logger(module_name: str) -> logging.Logger:
     logging.basicConfig(
         level=logging.DEBUG if is_debug_mode else logging.INFO,
         filename="dizznem_bot.log",
-        filemode="w",
+        filemode="a",
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,23 @@
+"""Tests for log.py."""
+
+import logging
+
+import log
+import pytest
+
+
+def test_set_up_logger_uses_append_filemode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that the log file is opened in append mode, not truncated.
+
+    Truncating on every start (the old "w" mode) destroys the log from
+    whatever crash caused the restart, right when it's needed most.
+    """
+    captured: dict = {}
+
+    def fake_basic_config(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+    log.set_up_logger("test_module")
+
+    assert captured["filemode"] == "a"


### PR DESCRIPTION
## Describe changes

- python/log.py: `logging.basicConfig()`'s `filemode` changed from `"w"` (truncate) to `"a"` (append).
- tests/test_log.py: new test file, 1 test -- monkeypatches `logging.basicConfig` to capture its kwargs and asserts `filemode == "a"`.
- CHANGELOG.md: added [Unreleased] entry.

Root cause: `filemode="w"` re-opens and truncates `dizznem_bot.log` every time `set_up_logger()` runs, which happens on every process start (it's called at import time). A restart is very often caused by a crash -- so the log lines explaining what went wrong get wiped out by the very restart that followed the crash, before anyone can read them. This is the smallest, safest possible fix (one word) but it directly affects our ability to diagnose any future crash on this bot, so I wanted to get it in on its own.

## Issue number

Fixes #N/A (found during a reliability audit, no filed issue)

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated (if applicable)