### PR TITLE
Fix wrong exception types caught around slash-command sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Slash-command sync failures at startup (rate limits, missing permissions, invalid command data) could crash the whole bot instead of being logged and skipped -- the code was catching the wrong exception types for what actually fails there.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/bot/bot.py
+++ b/python/bot/bot.py
@@ -16,6 +16,7 @@ from discord import (
     Message,
     TextChannel,
 )
+from discord.app_commands import AppCommandError
 from discord.ext import commands
 from log import logger
 from user import User, autosave
@@ -79,7 +80,7 @@ class DizznemBot(commands.Bot):
             logger.info("Syncing slash commands...")
             synced: list[AppCommand] = await self.tree.sync()
             logger.info(f"Successfully synced {len(synced)} commands.")
-        except (commands.ExtensionError, OSError) as e:
+        except (HTTPException, AppCommandError) as e:
             logger.error(f"Failed to sync commands: {e}")
 
         self.loop.create_task(autosave())

--- a/tests/test_bot_error_handling.py
+++ b/tests/test_bot_error_handling.py
@@ -1,0 +1,59 @@
+"""Tests for exception-handling correctness in bot/bot.py.
+
+CommandTree.sync() documents exactly five exception types it can raise
+(HTTPException, Forbidden, CommandSyncFailure, TranslationError,
+MissingApplicationID). setup_hook()'s except clause around that call must
+catch all five, or a routine sync failure (rate limit, missing scope, bad
+command data) crashes the entire bot startup instead of being logged.
+"""
+
+from discord import Forbidden, HTTPException
+from discord.app_commands import AppCommandError, CommandSyncFailure, TranslationError
+from discord.errors import MissingApplicationID
+
+# Mirrors the except tuple in bot/bot.py's setup_hook().
+SYNC_EXCEPT_TUPLE: tuple[type[Exception], ...] = (HTTPException, AppCommandError)
+
+
+class TestTreeSyncExceptionCoverage:
+    """Every exception CommandTree.sync() can raise must be caught."""
+
+    def test_http_exception_is_covered(self) -> None:
+        """Test that a plain HTTPException is covered."""
+        assert issubclass(HTTPException, SYNC_EXCEPT_TUPLE)
+
+    def test_forbidden_is_covered(self) -> None:
+        """Test that Forbidden (missing applications.commands scope) is covered."""
+        assert issubclass(Forbidden, SYNC_EXCEPT_TUPLE)
+
+    def test_command_sync_failure_is_covered(self) -> None:
+        """Test that CommandSyncFailure (invalid command data) is covered."""
+        assert issubclass(CommandSyncFailure, SYNC_EXCEPT_TUPLE)
+
+    def test_translation_error_is_covered(self) -> None:
+        """Test that TranslationError is covered."""
+        assert issubclass(TranslationError, SYNC_EXCEPT_TUPLE)
+
+    def test_missing_application_id_is_covered(self) -> None:
+        """Test that MissingApplicationID is covered."""
+        assert issubclass(MissingApplicationID, SYNC_EXCEPT_TUPLE)
+
+    def test_old_buggy_tuple_covered_none_of_these(self) -> None:
+        """Regression guard: documents the bug this fix corrects.
+
+        The old except tuple (commands.ExtensionError, OSError) matched
+        none of the real exception types sync() raises -- any sync
+        failure propagated uncaught out of setup_hook() and crashed
+        bot startup instead of being logged and skipped.
+        """
+        from discord.ext import commands
+
+        old_tuple: tuple[type[Exception], ...] = (commands.ExtensionError, OSError)
+        real_exceptions: tuple[type[Exception], ...] = (
+            HTTPException,
+            Forbidden,
+            CommandSyncFailure,
+            TranslationError,
+            MissingApplicationID,
+        )
+        assert not any(issubclass(exc, old_tuple) for exc in real_exceptions)


### PR DESCRIPTION
## Describe changes

- python/bot/bot.py: setup_hook()'s `except (commands.ExtensionError, OSError)` around `self.tree.sync()` replaced with `except (HTTPException, AppCommandError)`. Added `from discord.app_commands import AppCommandError` import (`HTTPException` was already imported).
- tests/test_bot_error_handling.py: new test file, 6 tests. Confirms each of the 5 exception types discord.py's own docstring says `CommandTree.sync()` can raise (HTTPException, Forbidden, CommandSyncFailure, TranslationError, MissingApplicationID) is a subclass of the new except tuple, plus a regression test proving the OLD tuple caught none of them.
- CHANGELOG.md: added [Unreleased] entry.

Root cause: verified directly against the installed discord.py source (`.venv/Lib/site-packages/discord/app_commands/tree.py` sync() docstring, and each exception class's actual base classes in `discord/errors.py` and `discord/app_commands/errors.py`). `commands.ExtensionError` is for cog/extension loading and has nothing to do with slash-command syncing; `sync()` never raises it or a plain `OSError`. The except clause was unreachable dead code -- any real sync failure (rate limit during frequent restarts, missing `applications.commands` scope, invalid command data) propagated straight out of `setup_hook()` uncaught, which aborts the entire bot startup instead of the intended log-and-continue behavior.

## Issue number

Fixes #N/A (found during a reliability audit, no filed issue)

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated (if applicable)