### PR TITLE
Save unsaved user data on SIGTERM before exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Up to a minute of money/level/prestige changes could be silently lost if the bot process was stopped (e.g. a `systemctl restart` or `docker stop`) rather than crashing -- unsaved data is now flushed to disk immediately when the stop signal is received, instead of relying only on the periodic autosave.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/main.py
+++ b/python/main.py
@@ -1,11 +1,14 @@
 """Main."""
 
 import os
+import signal
+import sys
+from types import FrameType
 
 from bot.bot import DizznemBot
 from dotenv import load_dotenv
 from log import logger
-from user import init_db
+from user import init_db, save_all_users
 
 load_dotenv()
 
@@ -26,6 +29,23 @@ def validate_env() -> bool:
     return not missing_vars
 
 
+def handle_sigterm(signum: int, frame: FrameType | None) -> None:  # noqa: ARG001
+    """Flush unsaved user data to disk before the process is terminated.
+
+    atexit handlers don't run on SIGTERM (the signal most process managers --
+    systemd, Docker, etc. -- send to stop a process), so without this, any
+    money/level/prestige changes made in the last SAVE_INTERVAL seconds would
+    be silently lost on every restart.
+
+    Args:
+        signum (int): The signal number received.
+        frame (FrameType | None): The current stack frame.
+    """
+    logger.info("Received SIGTERM, saving all users before exit...")
+    save_all_users()
+    sys.exit(0)
+
+
 def main() -> None:
     """Start bot."""
     logger.info("Starting Dizznem Bot...")
@@ -33,6 +53,7 @@ def main() -> None:
         return
 
     init_db()
+    signal.signal(signal.SIGTERM, handle_sigterm)
 
     try:
         bot: DizznemBot = DizznemBot()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,86 @@
+"""Tests for main.py."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from main import handle_sigterm
+from user import User
+
+
+@pytest.fixture
+def db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a temporary database for each test."""
+    db_path: Path = tmp_path / "users.db"
+    monkeypatch.setattr("user.DB_PATH", db_path)
+    monkeypatch.setattr("user.USER_CACHE", {})
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                money REAL DEFAULT 0,
+                prestige INTEGER DEFAULT 0,
+                level INTEGER DEFAULT 0,
+                message_count INTEGER DEFAULT 0
+            )
+            """,
+        )
+    return db_path
+
+
+class TestHandleSigterm:
+    """Tests for handle_sigterm."""
+
+    def test_saves_dirty_users_before_exiting(
+        self,
+        db: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that unsaved changes are flushed to disk before exit."""
+        user: User = User.create_if_not_exists(user_id=1, username="karma")
+        user.money = 5_000
+        assert user.dirty is True
+
+        monkeypatch.setattr("sys.exit", lambda *_a: (_ for _ in ()).throw(SystemExit))
+
+        with pytest.raises(SystemExit):
+            handle_sigterm(15, None)
+
+        with sqlite3.connect(db) as conn:
+            row: tuple = conn.execute(
+                "SELECT money FROM users WHERE id = 1",
+            ).fetchone()
+        assert row[0] == 5_000  # noqa: PLR2004
+
+    def test_exits_after_saving(
+        self,
+        db: Path,  # noqa: ARG002 -- fixture sets up user.DB_PATH/USER_CACHE
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that the process is told to exit after saving."""
+        exit_called: bool = False
+
+        def fake_exit(code: int = 0) -> None:
+            nonlocal exit_called
+            exit_called = True
+            assert code == 0
+
+        monkeypatch.setattr("sys.exit", fake_exit)
+        handle_sigterm(15, None)
+
+        assert exit_called is True
+
+    def test_no_dirty_users_still_exits_cleanly(
+        self,
+        db: Path,  # noqa: ARG002 -- fixture sets up user.DB_PATH/USER_CACHE
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that handling SIGTERM with no unsaved users doesn't error."""
+        monkeypatch.setattr("sys.exit", lambda *_a: (_ for _ in ()).throw(SystemExit))
+
+        with pytest.raises(SystemExit):
+            handle_sigterm(15, None)


### PR DESCRIPTION
## Describe changes

- python/main.py: added `handle_sigterm()`, registered via `signal.signal(signal.SIGTERM, handle_sigterm)` in `main()` before the bot starts. It logs, calls `save_all_users()` to flush every dirty user to disk, then `sys.exit(0)`.
- tests/test_main.py: new test file, 3 tests -- confirms an unsaved (dirty) change is actually written to the database before exit, confirms `sys.exit(0)` is called, and confirms handling SIGTERM with no dirty users doesn't error.
- CHANGELOG.md: added [Unreleased] entry.

Root cause: python/user.py's persistence model is write-behind -- changes to `user.money`/`level`/`prestige`/etc. only live in the in-memory `USER_CACHE` until either the 60-second `autosave()` loop runs, or `atexit.register(save_all_users)` fires at normal interpreter shutdown. `atexit` does not run on SIGTERM, which is the signal `systemctl restart`, `docker stop`, and most process managers send for a graceful stop (verified against discord.py's `Client.run()` source directly -- `.venv/Lib/site-packages/discord/client.py:920-938` -- it only catches `KeyboardInterrupt`, i.e. SIGINT, and installs no handling for SIGTERM at all). So a routine restart, not just a crash, could silently drop up to a minute of the most recent money/level/prestige changes with zero indication to the player.

## Issue number

Fixes #N/A (found during a reliability audit, no filed issue)

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated (if applicable)