### PR TITLE
Fix on_ready crash risk and repeat-send on reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- The startup "Hello" message could crash with an error if the configured test channel wasn't found, and would resend every time the bot reconnected to Discord (not just on first startup). Now it's skipped gracefully if the channel is missing, and only ever sent once.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/python/bot/bot.py
+++ b/python/bot/bot.py
@@ -55,6 +55,7 @@ class DizznemBot(commands.Bot):
         self.cache: dict[int, deque] = {}
         self.ai_cooldowns: dict[int, float] = {}
         self.ai_semaphore: asyncio.Semaphore = asyncio.Semaphore(3)
+        self._sent_ready_message: bool = False
 
     async def setup_hook(self) -> None:
         """Load all cogs and start autosave for database."""
@@ -86,12 +87,24 @@ class DizznemBot(commands.Bot):
         logger.info("Autosave task started.")
 
     async def on_ready(self) -> None:
-        """Bot startup."""
-        channel: TextChannel = cast(
-            "TextChannel",
-            self.get_channel(self.test_channel_id),
-        )
-        await channel.send("Hello")
+        """Bot startup.
+
+        Note: on_ready can fire more than once (e.g. on gateway reconnects),
+        so the startup message is only sent the first time.
+        """
+        if self._sent_ready_message:
+            logger.info("Bot reconnected.")
+            return
+
+        channel: TextChannel | None = self.get_channel(self.test_channel_id)  # type: ignore[assignment]
+        if channel is None:
+            logger.error(
+                f"Test channel {self.test_channel_id} not found; skipping startup message.",  # noqa: E501
+            )
+        else:
+            await channel.send("Hello")
+
+        self._sent_ready_message = True
         logger.info("Bot started.")
 
     async def on_command_error(self, ctx: commands.Context, error: Exception) -> None:

--- a/tests/test_bot_on_ready.py
+++ b/tests/test_bot_on_ready.py
@@ -1,0 +1,85 @@
+"""Tests for DizznemBot.on_ready in bot/bot.py."""
+
+import pytest
+from bot.bot import DizznemBot
+
+
+class FakeChannel:
+    """A minimal stand-in for a discord.TextChannel."""
+
+    def __init__(self) -> None:
+        """Initialize the fake channel."""
+        self.sent_messages: list[str] = []
+
+    async def send(self, content: str) -> None:
+        """Record a sent message instead of hitting the network.
+
+        Args:
+            content (str): The message content.
+        """
+        self.sent_messages.append(content)
+
+
+@pytest.fixture
+def bot() -> DizznemBot:
+    """Create a DizznemBot instance without connecting to Discord."""
+    return DizznemBot()
+
+
+class TestOnReady:
+    """Tests for on_ready."""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_missing_channel_does_not_raise(
+        self,
+        bot: DizznemBot,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that a missing test channel is handled instead of crashing."""
+        monkeypatch.setattr(bot, "get_channel", lambda _id: None)
+        await bot.on_ready()  # should not raise
+
+    async def test_sends_hello_when_channel_found(
+        self,
+        bot: DizznemBot,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that Hello is sent to the test channel when it's found."""
+        channel = FakeChannel()
+        monkeypatch.setattr(bot, "get_channel", lambda _id: channel)
+        await bot.on_ready()
+        assert channel.sent_messages == ["Hello"]
+
+    async def test_second_call_does_not_resend(
+        self,
+        bot: DizznemBot,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that a second on_ready (e.g. gateway reconnect) doesn't resend."""
+        channel = FakeChannel()
+        monkeypatch.setattr(bot, "get_channel", lambda _id: channel)
+
+        await bot.on_ready()
+        await bot.on_ready()
+
+        assert channel.sent_messages == ["Hello"]
+
+    async def test_second_call_does_not_touch_get_channel(
+        self,
+        bot: DizznemBot,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that a repeat on_ready short-circuits before looking up the channel."""
+        calls: list[int] = []
+
+        def fake_get_channel(channel_id: int) -> None:
+            calls.append(channel_id)
+            return None
+
+        monkeypatch.setattr(bot, "get_channel", fake_get_channel)
+
+        await bot.on_ready()
+        await bot.on_ready()
+
+        assert len(calls) == 1


### PR DESCRIPTION
## Describe changes

- python/bot/bot.py: `DizznemBot.__init__` gets a new `self._sent_ready_message: bool = False` flag.
- python/bot/bot.py: `on_ready()` now returns early (logging "Bot reconnected.") if the startup message was already sent, instead of re-running every time. When it does run, it now checks `channel is None` before calling `.send()` and logs an error instead of crashing if the configured test channel isn't found. Dropped the `cast("TextChannel", ...)` in favor of an honest `TextChannel | None` type now that the None case is actually handled.
- tests/test_bot_on_ready.py: new test file, 4 tests -- a missing channel doesn't raise, "Hello" is sent when the channel is found, a second `on_ready()` call doesn't resend, and a second call doesn't even look up the channel again.
- CHANGELOG.md: added [Unreleased] entry.

Root cause: `self.get_channel(self.test_channel_id)` returns `None` if the channel is missing or inaccessible, and the old code called `.send()` on that unguarded, raising `AttributeError`. Separately, `on_ready` is not a one-time startup hook -- confirmed against discord.py's own source: `.venv/Lib/site-packages/discord/state.py` dispatches the `'ready'` event from two separate code paths, and `Client.setup_hook`'s docstring explicitly recommends using it instead of `on_ready` because setup_hook "is only called once." So a correctly configured channel would get "Hello" resent every time the gateway reconnects (network blips, Discord-side restarts), not just once at actual startup. (setup_hook itself can't do this instead -- it runs *before* the websocket connection exists, so the channel cache isn't populated yet; confirmed via its own docstring warning about deadlocking on anything that waits for the websocket.)

## Issue number

Fixes #N/A (found during a reliability audit, no filed issue)

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated (if applicable)