### PR TITLE
Add warning system: $warn, $warnings, $delwarn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Added
+
+- Warning system: `$warn`, `$warnings`, and `$delwarn`.
+    - `$warn @user <reason>` issues a persistent warning (mod command, requires Moderate Members).
+    - `$warnings [@user]` shows a user's warning history (defaults to yourself; viewing others requires Moderate Members).
+    - `$delwarn <id>` removes a specific warning by ID (mod command, requires Moderate Members).
+    - Warnings are stored per-server, so IDs and history won't cross between servers the bot is in.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,10 +95,12 @@ python/
 │   ├── bot.py            # DizznemBot class
 │   └── cogs/             # All cogs live here
 │       ├── misc/
-│       └── money/
+│       ├── money/
+│       └── moderation/
 └── utils/                # Helpers used by cogs
     ├── misc/
     ├── money/
+    ├── moderation/
     ├── general.py
     └── numbers.py
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ python3 main.py
 | `$tictactoe <user>` | Challenge someone to Tic-Tac-Toe |
 | `$steal <user>` | Attempt to steal money from another user |
 
+### Moderator Commands
+
+| Command | Description |
+|---|---|
+| `$warn <user> <reason>` | Issue a persistent warning to a user (requires Moderate Members) |
+| `$warnings [user]` | View a user's warning history (defaults to yourself) |
+| `$delwarn <id>` | Remove a specific warning by ID (requires Moderate Members) |
+
 ### Admin Commands
 
 | `$setmoney <user> <amount>` | Set a user's balance to amount |

--- a/python/bot/cogs/moderation/__init__.py
+++ b/python/bot/cogs/moderation/__init__.py
@@ -1,0 +1,1 @@
+"""Init for moderation cogs."""

--- a/python/bot/cogs/moderation/moderation.py
+++ b/python/bot/cogs/moderation/moderation.py
@@ -1,0 +1,218 @@
+"""Warning system moderation commands.
+
+$warn / $warnings / $delwarn -- the foundation moderation primitive that
+later Phase 2 features (automod, mute escalation, mod logs) build on top of.
+"""
+
+from bot.bot import DizznemBot
+from discord import Color, Embed, Member
+from discord.ext import commands
+from log import logger  # noqa: F401
+from utils.moderation.warnings import (
+    WARNINGS_DB_PATH,
+    WarningRecord,
+    add_warning,
+    count_warnings,
+    delete_warning,
+    get_warnings,
+    validate_reason,
+)
+
+MAX_WARNINGS_DISPLAYED: int = 25
+
+
+class Moderation(commands.Cog):
+    """Warning system moderation commands."""
+
+    def __init__(self, bot: DizznemBot) -> None:
+        """Initialize Moderation.
+
+        Args:
+            bot (DizznemBot): Dizznem Bot.
+        """
+        self.bot: DizznemBot = bot
+
+    @commands.hybrid_command(
+        name="warn",
+        description="Issue a persistent warning to a user (mod command).",
+    )
+    @commands.guild_only()
+    @commands.has_permissions(moderate_members=True)
+    async def warn(
+        self,
+        ctx: commands.Context,
+        member: Member,
+        *,
+        reason: str,
+    ) -> None:
+        """Issue a persistent warning to a user.
+
+        Args:
+            ctx (commands.Context): Context.
+            member (Member): Member to warn.
+            reason (str): Reason for the warning.
+        """
+        if ctx.guild is None:
+            return
+
+        if member.bot:
+            await ctx.send(
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description="You cannot warn bots.",
+                ),
+                ephemeral=True,
+            )
+            return
+
+        if member.id == ctx.author.id:
+            await ctx.send(
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description="You cannot warn yourself.",
+                ),
+                ephemeral=True,
+            )
+            return
+
+        is_valid: bool
+        error_message: str
+        is_valid, error_message = validate_reason(reason)
+        if not is_valid:
+            await ctx.send(
+                embed=Embed(title="Error", color=Color.red(), description=error_message),
+                ephemeral=True,
+            )
+            return
+
+        warning: WarningRecord = add_warning(
+            WARNINGS_DB_PATH,
+            guild_id=ctx.guild.id,
+            user_id=member.id,
+            moderator_id=ctx.author.id,
+            reason=reason.strip(),
+        )
+        total: int = count_warnings(WARNINGS_DB_PATH, ctx.guild.id, member.id)
+
+        embed: Embed = Embed(
+            title="⚠️ User Warned",
+            color=Color.orange(),
+            description=(
+                f"**{member.display_name}** has been warned by "
+                f"**{ctx.author.display_name}**.\n\n"
+                f"**Reason:** {warning['reason']}"
+            ),
+        )
+        embed.set_footer(text=f"Warning ID: {warning['id']} • Total warnings: {total}")
+        await ctx.send(embed=embed)
+
+    @commands.hybrid_command(
+        name="warnings",
+        description="View a user's warning history.",
+    )
+    @commands.guild_only()
+    async def warnings_cmd(
+        self,
+        ctx: commands.Context,
+        member: Member | None = None,
+    ) -> None:
+        """View a user's warning history.
+
+        Viewing your own warnings is always allowed. Viewing someone else's
+        requires the Moderate Members permission.
+
+        Args:
+            ctx (commands.Context): Context.
+            member (Member | None): Member to view warnings for (defaults to self).
+        """
+        if ctx.guild is None:
+            return
+
+        target: Member = member or ctx.author  # pyright: ignore[reportAssignmentType]
+
+        if target.id != ctx.author.id and not ctx.author.guild_permissions.moderate_members:
+            await ctx.send(
+                embed=Embed(
+                    title="Missing Permissions",
+                    color=Color.red(),
+                    description="You do not have permission to view other users' warnings.",
+                ),
+                ephemeral=True,
+            )
+            return
+
+        records: list[WarningRecord] = get_warnings(WARNINGS_DB_PATH, ctx.guild.id, target.id)
+
+        if not records:
+            await ctx.send(
+                embed=Embed(
+                    title="ℹ️ No Warnings",  # noqa: RUF001
+                    color=Color.blue(),
+                    description=f"**{target.display_name}** has no warnings on record.",
+                ),
+            )
+            return
+
+        shown: list[WarningRecord] = records[-MAX_WARNINGS_DISPLAYED:]
+        lines: list[str] = [
+            f"**#{record['id']}** — <@{record['moderator_id']}>\n{record['reason']}"
+            for record in shown
+        ]
+
+        embed: Embed = Embed(
+            title=f"⚠️ Warnings for {target.display_name}",
+            color=Color.orange(),
+            description="\n\n".join(lines),
+        )
+        footer: str = f"Total warnings: {len(records)}"
+        if len(records) > MAX_WARNINGS_DISPLAYED:
+            footer += f" (showing most recent {MAX_WARNINGS_DISPLAYED})"
+        embed.set_footer(text=footer)
+        await ctx.send(embed=embed)
+
+    @commands.hybrid_command(
+        name="delwarn",
+        description="Remove a specific warning by ID (mod command).",
+    )
+    @commands.guild_only()
+    @commands.has_permissions(moderate_members=True)
+    async def delwarn(self, ctx: commands.Context, warning_id: int) -> None:
+        """Remove a specific warning by its ID.
+
+        Args:
+            ctx (commands.Context): Context.
+            warning_id (int): ID of the warning to remove.
+        """
+        if ctx.guild is None:
+            return
+
+        deleted: bool = delete_warning(WARNINGS_DB_PATH, ctx.guild.id, warning_id)
+
+        if not deleted:
+            await ctx.send(
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description=f"No warning with ID **{warning_id}** was found.",
+                ),
+                ephemeral=True,
+            )
+            return
+
+        embed: Embed = Embed(
+            title="✅ Warning Removed",
+            color=Color.green(),
+            description=f"Warning **#{warning_id}** has been removed.",
+        )
+        await ctx.send(embed=embed)
+
+
+async def setup(bot: DizznemBot) -> None:
+    """Setup for Moderation.
+
+    Args:
+        bot (DizznemBot): Dizznem Bot.
+    """
+    await bot.add_cog(Moderation(bot))

--- a/python/utils/moderation/__init__.py
+++ b/python/utils/moderation/__init__.py
@@ -1,0 +1,1 @@
+"""Init for moderation utils."""

--- a/python/utils/moderation/warnings.py
+++ b/python/utils/moderation/warnings.py
@@ -1,0 +1,229 @@
+"""Warning system database utilities.
+
+This is the foundation moderation primitive -- persistent, per-guild warning
+records that later Phase 2 features (automod, mute escalation, mod logs) can
+build on top of.
+"""
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TypedDict
+
+WARNINGS_DB_PATH: Path = Path("data/warnings.db")
+
+MAX_REASON_LENGTH: int = 500
+
+
+class WarningRecord(TypedDict):
+    """A single warning issued to a user."""
+
+    id: int
+    guild_id: int
+    user_id: int
+    moderator_id: int
+    reason: str
+    created_at: str
+
+
+def ensure_warnings_db(db_path: Path) -> None:
+    """Create warnings.db if it doesn't exist.
+
+    Args:
+        db_path (Path): Path to the SQLite database file.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS warnings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                guild_id INTEGER NOT NULL,
+                user_id INTEGER NOT NULL,
+                moderator_id INTEGER NOT NULL,
+                reason TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """,
+        )
+        conn.commit()
+
+
+def validate_reason(reason: str) -> tuple[bool, str]:
+    """Validate a warning reason before storing it.
+
+    Args:
+        reason (str): The reason text to validate.
+
+    Returns:
+        tuple[bool, str]: (is_valid, error_message)
+    """
+    stripped: str = reason.strip()
+
+    if not stripped:
+        return False, "Reason cannot be empty."
+
+    if len(stripped) > MAX_REASON_LENGTH:
+        return (
+            False,
+            f"Reason is too long. Must be {MAX_REASON_LENGTH} characters or less.",
+        )
+
+    return True, ""
+
+
+def add_warning(
+    db_path: Path,
+    guild_id: int,
+    user_id: int,
+    moderator_id: int,
+    reason: str,
+) -> WarningRecord:
+    """Add a warning for a user.
+
+    Args:
+        db_path (Path): SQLite database path.
+        guild_id (int): Discord guild ID the warning was issued in.
+        user_id (int): Discord user ID being warned.
+        moderator_id (int): Discord user ID of the moderator issuing the warning.
+        reason (str): Reason for the warning.
+
+    Returns:
+        WarningRecord: The newly created warning record.
+    """
+    ensure_warnings_db(db_path)
+    created_at: str = datetime.now(tz=UTC).isoformat()
+
+    with sqlite3.connect(db_path) as conn:
+        cursor: sqlite3.Cursor = conn.execute(
+            """
+            INSERT INTO warnings (guild_id, user_id, moderator_id, reason, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (guild_id, user_id, moderator_id, reason, created_at),
+        )
+        conn.commit()
+        new_id: int = cursor.lastrowid  # type: ignore[assignment]
+
+    return WarningRecord(
+        id=new_id,
+        guild_id=guild_id,
+        user_id=user_id,
+        moderator_id=moderator_id,
+        reason=reason,
+        created_at=created_at,
+    )
+
+
+def get_warnings(db_path: Path, guild_id: int, user_id: int) -> list[WarningRecord]:
+    """Get all warnings for a user in a guild, oldest first.
+
+    Args:
+        db_path (Path): SQLite database path.
+        guild_id (int): Discord guild ID.
+        user_id (int): Discord user ID.
+
+    Returns:
+        list[WarningRecord]: The user's warnings, ordered oldest to newest.
+    """
+    ensure_warnings_db(db_path)
+    with sqlite3.connect(db_path) as conn:
+        cursor: sqlite3.Cursor = conn.execute(
+            """
+            SELECT id, guild_id, user_id, moderator_id, reason, created_at
+            FROM warnings
+            WHERE guild_id = ? AND user_id = ?
+            ORDER BY id ASC
+            """,
+            (guild_id, user_id),
+        )
+        rows: list[tuple] = cursor.fetchall()
+
+    return [
+        WarningRecord(
+            id=row[0],
+            guild_id=row[1],
+            user_id=row[2],
+            moderator_id=row[3],
+            reason=row[4],
+            created_at=row[5],
+        )
+        for row in rows
+    ]
+
+
+def get_warning(db_path: Path, guild_id: int, warning_id: int) -> WarningRecord | None:
+    """Get a single warning by ID within a guild.
+
+    Args:
+        db_path (Path): SQLite database path.
+        guild_id (int): Discord guild ID the warning must belong to.
+        warning_id (int): ID of the warning to fetch.
+
+    Returns:
+        WarningRecord | None: The warning if found, otherwise None.
+    """
+    ensure_warnings_db(db_path)
+    with sqlite3.connect(db_path) as conn:
+        cursor: sqlite3.Cursor = conn.execute(
+            """
+            SELECT id, guild_id, user_id, moderator_id, reason, created_at
+            FROM warnings
+            WHERE id = ? AND guild_id = ?
+            """,
+            (warning_id, guild_id),
+        )
+        row: tuple | None = cursor.fetchone()
+
+    if row is None:
+        return None
+
+    return WarningRecord(
+        id=row[0],
+        guild_id=row[1],
+        user_id=row[2],
+        moderator_id=row[3],
+        reason=row[4],
+        created_at=row[5],
+    )
+
+
+def delete_warning(db_path: Path, guild_id: int, warning_id: int) -> bool:
+    """Delete a specific warning by ID within a guild.
+
+    Args:
+        db_path (Path): SQLite database path.
+        guild_id (int): Discord guild ID the warning must belong to.
+        warning_id (int): ID of the warning to delete.
+
+    Returns:
+        bool: True if a warning was deleted, False if none matched.
+    """
+    ensure_warnings_db(db_path)
+    with sqlite3.connect(db_path) as conn:
+        cursor: sqlite3.Cursor = conn.execute(
+            "DELETE FROM warnings WHERE id = ? AND guild_id = ?",
+            (warning_id, guild_id),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+
+
+def count_warnings(db_path: Path, guild_id: int, user_id: int) -> int:
+    """Count how many warnings a user has in a guild.
+
+    Args:
+        db_path (Path): SQLite database path.
+        guild_id (int): Discord guild ID.
+        user_id (int): Discord user ID.
+
+    Returns:
+        int: Number of warnings on record.
+    """
+    ensure_warnings_db(db_path)
+    with sqlite3.connect(db_path) as conn:
+        cursor: sqlite3.Cursor = conn.execute(
+            "SELECT COUNT(*) FROM warnings WHERE guild_id = ? AND user_id = ?",
+            (guild_id, user_id),
+        )
+        return cursor.fetchone()[0]

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,222 @@
+"""Tests for utils/moderation/warnings.py."""
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+from utils.moderation.warnings import (
+    MAX_REASON_LENGTH,
+    WarningRecord,
+    add_warning,
+    count_warnings,
+    delete_warning,
+    ensure_warnings_db,
+    get_warning,
+    get_warnings,
+    validate_reason,
+)
+
+GUILD_ID: int = 111
+OTHER_GUILD_ID: int = 222
+USER_ID: int = 555
+MODERATOR_ID: int = 999
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Path:
+    """Create a temporary warnings database for each test."""
+    return tmp_path / "warnings.db"
+
+
+class TestEnsureWarningsDb:
+    """Tests for ensure_warnings_db."""
+
+    def test_creates_table(self, db: Path) -> None:
+        """Test that the warnings table is created."""
+        ensure_warnings_db(db)
+        with sqlite3.connect(db) as conn:
+            cursor: sqlite3.Cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='warnings'",
+            )
+            assert cursor.fetchone() is not None
+
+    def test_idempotent(self, db: Path) -> None:
+        """Test that calling ensure_warnings_db twice does not error or wipe data."""
+        ensure_warnings_db(db)
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "spamming")
+        ensure_warnings_db(db)
+        assert count_warnings(db, GUILD_ID, USER_ID) == 1
+
+
+class TestValidateReason:
+    """Tests for validate_reason."""
+
+    def test_valid_reason(self) -> None:
+        """Test that a normal reason passes validation."""
+        is_valid, message = validate_reason("Spamming in general chat")
+        assert is_valid is True
+        assert message == ""
+
+    def test_empty_reason_rejected(self) -> None:
+        """Test that an empty reason is rejected."""
+        is_valid, message = validate_reason("")
+        assert is_valid is False
+        assert "empty" in message.lower()
+
+    def test_whitespace_only_reason_rejected(self) -> None:
+        """Test that a whitespace-only reason is rejected."""
+        is_valid, message = validate_reason("   ")
+        assert is_valid is False
+        assert "empty" in message.lower()
+
+    def test_too_long_reason_rejected(self) -> None:
+        """Test that a reason over MAX_REASON_LENGTH is rejected."""
+        is_valid, message = validate_reason("x" * (MAX_REASON_LENGTH + 1))
+        assert is_valid is False
+        assert "too long" in message.lower()
+
+    def test_reason_at_max_length_accepted(self) -> None:
+        """Test that a reason exactly at MAX_REASON_LENGTH is accepted."""
+        is_valid, _message = validate_reason("x" * MAX_REASON_LENGTH)
+        assert is_valid is True
+
+
+class TestAddWarning:
+    """Tests for add_warning."""
+
+    def test_returns_warning_record(self, db: Path) -> None:
+        """Test that add_warning returns a populated WarningRecord."""
+        warning: WarningRecord = add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "rule 1")
+        assert warning["guild_id"] == GUILD_ID
+        assert warning["user_id"] == USER_ID
+        assert warning["moderator_id"] == MODERATOR_ID
+        assert warning["reason"] == "rule 1"
+        assert warning["id"] > 0
+
+    def test_persists_to_database(self, db: Path) -> None:
+        """Test that the warning is actually written to the database."""
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "rule 1")
+        with sqlite3.connect(db) as conn:
+            row: Any = conn.execute("SELECT COUNT(*) FROM warnings").fetchone()
+        assert row[0] == 1
+
+    def test_ids_increment(self, db: Path) -> None:
+        """Test that successive warnings get increasing IDs."""
+        first: WarningRecord = add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "first")
+        second: WarningRecord = add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "second")
+        assert second["id"] > first["id"]
+
+
+class TestGetWarnings:
+    """Tests for get_warnings."""
+
+    def test_returns_empty_list_when_none(self, db: Path) -> None:
+        """Test that a user with no warnings gets an empty list."""
+        assert get_warnings(db, GUILD_ID, USER_ID) == []
+
+    def test_returns_all_warnings_for_user(self, db: Path) -> None:
+        """Test that all warnings for a user are returned."""
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "first")
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "second")
+        records: list[WarningRecord] = get_warnings(db, GUILD_ID, USER_ID)
+        assert len(records) == 2  # noqa: PLR2004
+
+    def test_ordered_oldest_first(self, db: Path) -> None:
+        """Test that warnings come back in creation order."""
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "first")
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "second")
+        records: list[WarningRecord] = get_warnings(db, GUILD_ID, USER_ID)
+        assert records[0]["reason"] == "first"
+        assert records[1]["reason"] == "second"
+
+    def test_scoped_to_guild(self, db: Path) -> None:
+        """Test that warnings from another guild are not returned."""
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "here")
+        add_warning(db, OTHER_GUILD_ID, USER_ID, MODERATOR_ID, "elsewhere")
+        records: list[WarningRecord] = get_warnings(db, GUILD_ID, USER_ID)
+        assert len(records) == 1
+        assert records[0]["reason"] == "here"
+
+    def test_scoped_to_user(self, db: Path) -> None:
+        """Test that another user's warnings are not returned."""
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "target")
+        add_warning(db, GUILD_ID, MODERATOR_ID, USER_ID, "someone else")
+        records: list[WarningRecord] = get_warnings(db, GUILD_ID, USER_ID)
+        assert len(records) == 1
+        assert records[0]["reason"] == "target"
+
+
+class TestGetWarning:
+    """Tests for get_warning."""
+
+    def test_returns_matching_warning(self, db: Path) -> None:
+        """Test that a warning is returned by ID."""
+        created: WarningRecord = add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "rule 1")
+        fetched: WarningRecord | None = get_warning(db, GUILD_ID, created["id"])
+        assert fetched is not None
+        assert fetched["reason"] == "rule 1"
+
+    def test_returns_none_when_missing(self, db: Path) -> None:
+        """Test that None is returned for a non-existent warning ID."""
+        ensure_warnings_db(db)
+        assert get_warning(db, GUILD_ID, 12345) is None
+
+    def test_returns_none_for_wrong_guild(self, db: Path) -> None:
+        """Test that a warning cannot be fetched using the wrong guild ID."""
+        created: WarningRecord = add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "rule 1")
+        assert get_warning(db, OTHER_GUILD_ID, created["id"]) is None
+
+
+class TestDeleteWarning:
+    """Tests for delete_warning."""
+
+    def test_deletes_existing_warning(self, db: Path) -> None:
+        """Test that deleting an existing warning returns True and removes it."""
+        created: WarningRecord = add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "rule 1")
+        result: bool = delete_warning(db, GUILD_ID, created["id"])
+        assert result is True
+        assert get_warnings(db, GUILD_ID, USER_ID) == []
+
+    def test_returns_false_for_missing_id(self, db: Path) -> None:
+        """Test that deleting a non-existent warning ID returns False."""
+        ensure_warnings_db(db)
+        assert delete_warning(db, GUILD_ID, 99999) is False
+
+    def test_does_not_delete_across_guilds(self, db: Path) -> None:
+        """Test that a warning cannot be deleted using the wrong guild ID."""
+        created: WarningRecord = add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "rule 1")
+        result: bool = delete_warning(db, OTHER_GUILD_ID, created["id"])
+        assert result is False
+        assert len(get_warnings(db, GUILD_ID, USER_ID)) == 1
+
+    def test_only_deletes_targeted_warning(self, db: Path) -> None:
+        """Test that deleting one warning leaves the others intact."""
+        first: WarningRecord = add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "first")
+        second: WarningRecord = add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "second")
+        delete_warning(db, GUILD_ID, first["id"])
+        remaining: list[WarningRecord] = get_warnings(db, GUILD_ID, USER_ID)
+        assert len(remaining) == 1
+        assert remaining[0]["id"] == second["id"]
+
+
+class TestCountWarnings:
+    """Tests for count_warnings."""
+
+    def test_zero_when_none(self, db: Path) -> None:
+        """Test that count is zero for a user with no warnings."""
+        assert count_warnings(db, GUILD_ID, USER_ID) == 0
+
+    def test_counts_correctly(self, db: Path) -> None:
+        """Test that the count matches the number of warnings added."""
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "one")
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "two")
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "three")
+        assert count_warnings(db, GUILD_ID, USER_ID) == 3  # noqa: PLR2004
+
+    def test_decrements_after_delete(self, db: Path) -> None:
+        """Test that the count reflects a deleted warning."""
+        first: WarningRecord = add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "one")
+        add_warning(db, GUILD_ID, USER_ID, MODERATOR_ID, "two")
+        delete_warning(db, GUILD_ID, first["id"])
+        assert count_warnings(db, GUILD_ID, USER_ID) == 1


### PR DESCRIPTION
## Describe changes

- python/utils/moderation/warnings.py: new module -- SQLite warnings table (guild_id, user_id, moderator_id, reason, created_at), add_warning, get_warnings, get_warning, delete_warning, count_warnings, validate_reason (non-empty, 500 char max). Every read/delete query is scoped by guild_id, including a compound WHERE id = ? AND guild_id = ? on lookups/deletes, so a warning ID from one server can't be viewed or removed via a different server.
- python/utils/moderation/__init__.py, python/bot/cogs/moderation/__init__.py: new package inits.
- python/bot/cogs/moderation/moderation.py: new Moderation cog -- $warn <user> <reason> (blocks self-warns and warning bots, requires Moderate Members), $warnings [user] (defaults to yourself with no permission needed; viewing someone else requires Moderate Members), $delwarn <id> (requires Moderate Members). All guild-only.
- tests/test_warnings.py: new test file, 25 tests -- reason validation, CRUD correctness, and dedicated cross-guild isolation tests (a warning from guild A is not returned, fetched, or deletable via guild B).
- CHANGELOG.md: added [Unreleased] entry.
- README.md: added a Moderator Commands table.
- CONTRIBUTING.md: updated the project structure tree to include the new moderation/ packages.

This is the first Phase 2 (invent) pick from the North Star loop -- with all filed GitHub issues now cleared, it picked the smallest foundation piece of the roadmap's #1 stated priority (moderation & safety) rather than something bigger: a persistent warning system that later features (automod, mute escalation, mod logs) can build on.

Verified independently: checked out the branch, ran the full test suite myself (225/225 passing) and `ruff check` (clean), and specifically checked the cross-server security boundary since warning IDs are a single global auto-increment counter shared across every guild the bot is in -- confirmed every lookup/delete requires a `guild_id` match, not just the ID, so a moderator in one server can't enumerate or delete another server's warnings by guessing IDs. Permission gating uses Discord's real `Moderate Members` permission (`@commands.has_permissions`) rather than the single-hardcoded-admin pattern used elsewhere in this repo, which is the correct choice here since moderation needs to be delegable to each server's own mod role.

## Issue number

Fixes #N/A (Phase 2 original feature, no filed issue -- built per the North Star roadmap's moderation-first priority)

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated (if applicable)