### PR TITLE
Chore: maintenance sweep (typos, silent failure, error-message consistency, log context)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Dizznem Bot Changelog
 
+## [Unreleased]
+
+### Changed
+
+- A handful of error messages (`$tictactoe`, `$buystock`/`$sellstock`, `$inspiration`) now use the same embed format as every other error reply in the bot, instead of plain text.
+
 ## [2.3.1] - 2026-7-19
 
 ### Fixed

--- a/SKIPPED.md
+++ b/SKIPPED.md
@@ -1,0 +1,63 @@
+# Maintenance Sweep — Skipped Items
+
+Found during the `chore/maintenance-sweep` pass but not touched, because each one
+was either outside the whitelist, ambiguous, or required a judgment call the
+whitelist explicitly said to skip rather than make. Ranked by apparent severity.
+No action needed to receive this — it's a backlog, not a task list.
+
+## 1. Unguarded dict-key access on external (yt-dlp) data — youtube.py
+
+**File:lines:** `python/bot/cogs/misc/youtube.py:279, 391, 400, 571, 586, 633`
+
+Six spots build a "Now Playing" / queue embed via `self.current['title']`,
+`info['title']`, `item['title']` (and matching `'webpage_url'` accesses) with
+direct bracket indexing, not `.get()`. If yt-dlp ever returns an info dict
+missing one of those keys (malformed/private/deleted video metadata), this
+raises an unguarded `KeyError`.
+
+**Why skipped:** this isn't classic user-input validation (it's external API
+response data), and the whitelist's category 5 explicitly forbids adding
+default values/coercion as the fix — so swapping to `.get("title", "Unknown")`
+would violate the same rule that would justify touching it. A category-5-
+compliant fix (early-return guard, no defaults) doesn't have an obvious shape
+inside an embed-building loop over multiple queue items. Also, `youtube.py` is
+already being modified by a separate in-flight PR this session
+(`fix/youtube-playback-errors`), so touching it again here risks compounding
+merge conflicts for something that needs a real design decision, not a
+mechanical fix.
+
+## 2. `interaction.response.send_message` error formatting is genuinely mixed, not dominant
+
+**Files:** `python/utils/money/stock_views.py` (7 call sites), `python/utils/money/store_views.py` (2 ownership-check call sites, but its own `_insufficient_funds` helper uses Embed), `python/bot/cogs/misc/games.py:71-86` (3 call sites)
+
+Command-level errors (`ctx.send`) consistently use `Embed(title="Error", color=Color.red())` throughout the repo, so that pattern was safe to align to (see `[category 4]` commits below). But interaction-based errors (button/modal `interaction.response.send_message`) are a genuine mix: most are plain text, but `StoreView._insufficient_funds` deliberately uses a richer `❌ Insufficient Funds` embed. There's no single dominant format for this specific call type to align to.
+
+I actually made this mistake once during the sweep — converted `stock_views.py`'s `AmountModal.on_submit` to Embed, then caught that it made the file *less* internally consistent (2 Embed vs. 7 remaining plain-text calls in the same file), and reverted it (see the revert commit below). Standardizing this properly is a real design decision (pick one format for interaction errors and migrate all ~12 call sites together) — not a mechanical align-to-existing-pattern fix, so it's out of scope for this whitelist.
+
+## 3. `# noqa: F401` logger imports — not actually dead code
+
+**Files:lines:** `python/bot/cogs/_template.py:5`, `python/bot/cogs/money/money_making.py:10`, `python/bot/cogs/money/money.py:8`, `python/bot/cogs/misc/admin.py:12`, `python/bot/cogs/misc/user_info.py:6`
+
+`from log import logger` with no other use of `logger` in the file, `# noqa: F401` suppressing the unused-import lint warning. Looked like dead-code candidates at first, but `_template.py`'s copy has an explicit comment: `# noqa: F401 -- Import logger for possible use.` This is a deliberate, repo-wide boilerplate convention (every new cog gets a ready-to-use logger import via the template), not an accidental unused import. Category 2 requires "provably unreferenced" with no ambiguity — this has clear evidence of intentionality, so it's a skip, not a removal.
+
+## 4. Vaulted pride-month trigger — intentionally commented out
+
+**File:line:** `python/bot/bot.py:202`
+
+```python
+# ("gay", "Dizznem Bot is an LGBTQ+ ally!"),  # Vaulted pride month command
+```
+
+Commented-out code, which is category 2's territory on its face -- but the
+inline "Vaulted" annotation plus the CHANGELOG history (pride-month response
+commands were explicitly added in 2.2.0 and removed in 2.2.1, on a seasonal
+cadence) both indicate this is a deliberate archive for reactivation, not
+forgotten cruft. Skipped.
+
+---
+
+**Everything else** in the seven whitelist categories was either already
+clean (ruff already enforces unused-import/unused-variable removal on this
+repo by default, even with no `ruff.toml` present on `main`, so category 2's
+low-hanging fruit was already covered before this sweep started) or is listed
+above.

--- a/python/bot/bot.py
+++ b/python/bot/bot.py
@@ -182,7 +182,7 @@ class DizznemBot(commands.Bot):
                     f"(no channel or DM permission)",
                 )
         except HTTPException as e:
-            logger.error(f"Failed to send level up message: {e}")
+            logger.error(f"Failed to send level up message to {message.author}: {e}")
 
     async def _handle_triggers(self, message: Message) -> None:
         """Check message content against triggers and respond accordingly.

--- a/python/bot/cogs/misc/ai.py
+++ b/python/bot/cogs/misc/ai.py
@@ -99,6 +99,10 @@ class AI(commands.Cog):
         try:
             return await ctx.channel.fetch_message(reference.message_id)
         except HTTPException:
+            logger.debug(
+                f"Failed to fetch replied-to message {reference.message_id} "
+                f"in channel {ctx.channel.id}; falling back to channel history.",
+            )
             return None
 
     @commands.hybrid_command(

--- a/python/bot/cogs/misc/games.py
+++ b/python/bot/cogs/misc/games.py
@@ -1,7 +1,7 @@
 """Interactive Dizzle game commands."""
 
 from bot.bot import DizznemBot
-from discord import ButtonStyle, Interaction, Member, Message
+from discord import ButtonStyle, Color, Embed, Interaction, Member, Message
 from discord.ext import commands
 from discord.ui import Button, View
 from utils.misc.tictactoe import get_winner, is_draw
@@ -147,10 +147,24 @@ class Games(commands.Cog):
             opponent: The member challenged to play O.
         """
         if opponent.id == ctx.author.id:
-            await ctx.send("You cannot challenge yourself.", ephemeral=True)
+            await ctx.send(
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description="You cannot challenge yourself.",
+                ),
+                ephemeral=True,
+            )
             return
         if opponent.bot:
-            await ctx.send("Bots do not play Tic-Tac-Toe. They have scripts to write.", ephemeral=True)
+            await ctx.send(
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description="Bots do not play Tic-Tac-Toe. They have scripts to write.",
+                ),
+                ephemeral=True,
+            )
             return
 
         player_x: Member = ctx.author  # type: ignore[assignment]

--- a/python/bot/cogs/misc/misc.py
+++ b/python/bot/cogs/misc/misc.py
@@ -113,7 +113,11 @@ class Misc(commands.Cog):
         quote: str | None = get_random_quote(INSPIRATION_DB_PATH)
         if quote is None:
             await ctx.send(
-                "No inspirational quotes found in the database.",
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description="No inspirational quotes found in the database.",
+                ),
                 ephemeral=True,
             )
             return

--- a/python/bot/cogs/money/stocks.py
+++ b/python/bot/cogs/money/stocks.py
@@ -103,14 +103,25 @@ class Stocks(commands.Cog):
         )
         if match is None:
             await ctx.send(
-                f"`{stock}` is not a valid stock. Use `/stockmarket` to see all stocks.",
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description=f"`{stock}` is not a valid stock. Use `/stockmarket` to see all stocks.",  # noqa: E501
+                ),
                 ephemeral=True,
             )
             return
 
         price: float | None = get_price(USERS_DB_PATH, match)
         if price is None:
-            await ctx.send("Could not retrieve stock price.", ephemeral=True)
+            await ctx.send(
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description="Could not retrieve stock price.",
+                ),
+                ephemeral=True,
+            )
             return
 
         balance: float = get_user_balance(ctx.author.id, ctx.author.name)
@@ -144,14 +155,25 @@ class Stocks(commands.Cog):
         )
         if match is None:
             await ctx.send(
-                f"`{stock}` is not a valid stock. Use `/stockmarket` to see all stocks.",
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description=f"`{stock}` is not a valid stock. Use `/stockmarket` to see all stocks.",  # noqa: E501
+                ),
                 ephemeral=True,
             )
             return
 
         price: float | None = get_price(USERS_DB_PATH, match)
         if price is None:
-            await ctx.send("Could not retrieve stock price.", ephemeral=True)
+            await ctx.send(
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description="Could not retrieve stock price.",
+                ),
+                ephemeral=True,
+            )
             return
 
         holdings: list[tuple[str, int, float]] = get_user_stocks(
@@ -160,7 +182,14 @@ class Stocks(commands.Cog):
         )
         owned: int = next((qty for name, qty, _ in holdings if name == match), 0)
         if owned == 0:
-            await ctx.send(f"You don't own any **{match}** shares.", ephemeral=True)
+            await ctx.send(
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description=f"You don't own any **{match}** shares.",
+                ),
+                ephemeral=True,
+            )
             return
 
         view: SellView = SellView(

--- a/python/user.py
+++ b/python/user.py
@@ -15,7 +15,7 @@ SAVE_INTERVAL: int = 60
 
 
 def init_db() -> None:
-    """Initalize database if not done so already."""
+    """Initialize database if not done so already."""
     logger.info("Initiating database...")
 
     DB_PATH.parent.mkdir(exist_ok=True)
@@ -33,7 +33,7 @@ def init_db() -> None:
         """,
         )
 
-    logger.info("Database initalized.")
+    logger.info("Database initialized.")
 
 
 class User:

--- a/python/utils/money/stock_views.py
+++ b/python/utils/money/stock_views.py
@@ -35,14 +35,22 @@ class AmountModal(Modal, title="Enter Amount"):
             amount: int = int(self.amount.value)
         except ValueError:
             await interaction.response.send_message(
-                "Please enter a valid whole number.",
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description="Please enter a valid whole number.",
+                ),
                 ephemeral=True,
             )
             return
 
         if amount <= 0:
             await interaction.response.send_message(
-                "Amount must be greater than 0.",
+                embed=Embed(
+                    title="Error",
+                    color=Color.red(),
+                    description="Amount must be greater than 0.",
+                ),
                 ephemeral=True,
             )
             return

--- a/python/utils/money/stock_views.py
+++ b/python/utils/money/stock_views.py
@@ -35,22 +35,14 @@ class AmountModal(Modal, title="Enter Amount"):
             amount: int = int(self.amount.value)
         except ValueError:
             await interaction.response.send_message(
-                embed=Embed(
-                    title="Error",
-                    color=Color.red(),
-                    description="Please enter a valid whole number.",
-                ),
+                "Please enter a valid whole number.",
                 ephemeral=True,
             )
             return
 
         if amount <= 0:
             await interaction.response.send_message(
-                embed=Embed(
-                    title="Error",
-                    color=Color.red(),
-                    description="Amount must be greater than 0.",
-                ),
+                "Amount must be greater than 0.",
                 ephemeral=True,
             )
             return


### PR DESCRIPTION
## Describe changes

**[category 1] Typos**
- python/user.py: fixed "Initalize"/"initalized" -> "Initialize"/"initialized" (docstring + log line).

**[category 3] Silent failures made loud**
- python/bot/cogs/misc/ai.py: `_get_replied_message()` now logs a debug line (message ID + channel ID) when fetching a replied-to message fails, before silently falling back to normal channel-history summarization. Previously this failure had zero trace anywhere.

**[category 4] Error message consistency**
- python/bot/cogs/misc/games.py: `$tictactoe`'s two validation errors ("cannot challenge yourself", "bots do not play") now use the same `Embed(title="Error", color=Color.red())` format used almost everywhere else in the bot, instead of plain text.
- python/bot/cogs/money/stocks.py: `$buystock`/`$sellstock`'s four error replies (invalid stock, price unavailable x2, no shares owned) aligned to the same Embed pattern.
- python/bot/cogs/misc/misc.py: `$inspiration`'s "no quotes found" error aligned to the same Embed pattern.
- Note: I also converted `stock_views.py`'s modal validation errors to Embed, then reverted it (see the revert commit) after discovering that `interaction.response.send_message`-based errors are actually a genuine mix of plain-text and Embed across the codebase, not a single dominant format -- converting those two calls made that file *less* internally consistent, not more. Flagged for the head dev in SKIPPED.md instead of guessing at a real design decision.

**[category 6] Log hygiene**
- python/bot/bot.py: `_handle_level_up`'s HTTPException log line now includes which user the send failed for, matching the sibling Forbidden-branch log line that already had this context.

**Other files**
- CHANGELOG.md: added an [Unreleased] entry for the one genuinely user-facing bit (the error-message formatting).
- SKIPPED.md: everything found but not touched, with file:line and reasoning -- an unguarded dict-key-access risk in youtube.py (ambiguous fix shape, and that file has an in-flight PR already), the interaction-error mixed-pattern issue above, five intentionally-`noqa`'d logger imports that turned out to be a deliberate per-cog boilerplate convention (not dead code), and one deliberately-vaulted pride-month trigger comment.

Every commit was verified individually: ran the full test suite (200/200 passing throughout) and `ruff check` after each change, before committing. Nothing here touches the Genshin or prediction-market modules, any config/env/secrets/schema/migration file, any public function signature, or any dependency file, per the sweep's own exclusion list.

## Issue number

Fixes #N/A (maintenance sweep, no filed issue)

## Checklist
- [x] No tokens, API keys, or secrets are hardcoded
- [ ] .env.example updated if new environment variables were added
- [x] No breaking changes to existing commands (or noted below if so)
- [ ] Tested in Discord manually
- [x] pytest passes with no errors
- [x] CHANGELOG.md updated (if applicable)